### PR TITLE
Limit windowws dependency (by using windowss-core and the thiner sys crate that use windows_sys)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ repository = "https://github.com/mveril/wslplugins-rs"
 description = "A Rust framework for developing WSL plugins using safe and idiomatic Rust."
 
 [patch.crates-io]
-wslpluginapi-sys = { version = "0.1.0-rc.1", git = "https://github.com/mveril/wslpluginapi-sys.git", rev = "refs/pull/38/head" }
+wslpluginapi-sys = { version = "0.1.0-rc.1", git = "https://github.com/mveril/wslpluginapi-sys.git", branch = "develop" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ repository = "https://github.com/mveril/wslplugins-rs"
 description = "A Rust framework for developing WSL plugins using safe and idiomatic Rust."
 
 [patch.crates-io]
-wslpluginapi-sys = { version = "0.1.0-rc.1", git = "https://github.com/mveril/wslpluginapi-sys.git", branch = "release/0.1.0-rc.1+2.4.4" }
+wslpluginapi-sys = { version = "0.1.0-rc.1", git = "https://github.com/mveril/wslpluginapi-sys.git", rev = "refs/pull/38/head" }

--- a/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
+++ b/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
@@ -13,7 +13,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 settings: *const ::wslplugins_rs::sys::WSLVmCreationSettings,
-            ) -> i32 {
+            ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let settings_ptr = unsafe { &*settings };
                 let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
@@ -31,7 +31,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
         Hooks::OnVMStopping => Some(quote! {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation
-            ) -> i32 {
+            ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
                     plugin.#trait_method_ident(session_ptr.as_ref()).into()
@@ -45,7 +45,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution: *const ::wslplugins_rs::sys::WSLDistributionInformation,
-            ) -> i32 {
+            ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
                 let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
@@ -64,7 +64,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution: *const ::wslplugins_rs::sys::WSLDistributionInformation,
-            ) -> i32 {
+            ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
                 let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
@@ -82,7 +82,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution:  *const ::wslplugins_rs::sys::WSLOfflineDistributionInformation,
-            ) -> i32 {
+            ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
                 let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
@@ -100,7 +100,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution:  *const ::wslplugins_rs::sys::WSLOfflineDistributionInformation,
-            ) -> i32 {
+            ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
                 let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {

--- a/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
+++ b/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
@@ -33,7 +33,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                 PLUGIN.get()
                     .map(|plugin| {
                         let result = plugin.#trait_method_ident(session_ptr.as_ref());
-                        windows::core::HRESULT::from(result).0
+                        ::wslplugins_rs::windows_core::HRESULT::from(result).0
                     })
                     .unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_FAIL)
             }
@@ -50,7 +50,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     );
-                    windows::core::HRESULT::from(::wslplugins_rs::plugin::utils::consume_to_win_result(result)).0
+                    ::wslplugins_rs::windows_core::HRESULT::from(::wslplugins_rs::plugin::utils::consume_to_win_result(result)).0
                 }).unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_FAIL)
             }
         }),
@@ -62,7 +62,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
                 PLUGIN.get().map(|plugin|{
-                    windows::core::HRESULT::from(plugin.#trait_method_ident(
+                    ::wslplugins_rs::windows_core::HRESULT::from(plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     )).0
@@ -77,7 +77,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
                 PLUGIN.get().map(|plugin|{
-                    windows::core::HRESULT::from(plugin.#trait_method_ident(
+                    ::wslplugins_rs::windows_core::HRESULT::from(plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     )).0
@@ -92,7 +92,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
                 PLUGIN.get().map(|plugin|{
-                    windows::core::HRESULT::from(plugin.#trait_method_ident(
+                    ::wslplugins_rs::windows_core::HRESULT::from(plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     )).0

--- a/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
+++ b/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
@@ -13,10 +13,10 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 settings: *const ::wslplugins_rs::sys::WSLVmCreationSettings,
-            ) -> ::windows::core::HRESULT {
+            ) -> i32 {
                 let session_ptr = unsafe { &*session };
                 let settings_ptr = unsafe { &*settings };
-                if let Some(plugin) = PLUGIN.get() {
+                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
                     let result = plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         settings_ptr.as_ref(),
@@ -24,29 +24,31 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                     ::wslplugins_rs::plugin::utils::consume_to_win_result(result).into()
                 } else {
                     ::windows::Win32::Foundation::E_FAIL
-                }
+                };
+                hresult.0
             }
         }),
         Hooks::OnVMStopping => Some(quote! {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation
-            ) -> ::windows::core::HRESULT {
+            ) -> i32 {
                 let session_ptr = unsafe { &*session };
-                if let Some(plugin) = PLUGIN.get() {
+                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
                     plugin.#trait_method_ident(session_ptr.as_ref()).into()
                 } else {
                     ::windows::Win32::Foundation::E_FAIL
-                }
+                };
+                hresult.0
             }
         }),
         Hooks::OnDistributionStarted => Some(quote! {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution: *const ::wslplugins_rs::sys::WSLDistributionInformation,
-            ) -> ::windows::core::HRESULT {
+            ) -> i32 {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                if let Some(plugin) = PLUGIN.get() {
+                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
                     let result = plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
@@ -54,58 +56,62 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                     ::wslplugins_rs::plugin::utils::consume_to_win_result(result).into()
                 } else {
                     ::windows::Win32::Foundation::E_FAIL
-                }
+                };
+                hresult.0
             }
         }),
         Hooks::OnDistributionStopping => Some(quote! {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution: *const ::wslplugins_rs::sys::WSLDistributionInformation,
-            ) -> ::windows::core::HRESULT {
+            ) -> i32 {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                if let Some(plugin) = PLUGIN.get() {
+                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
                     plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     ).into()
                 } else {
                     ::windows::Win32::Foundation::E_FAIL
-                }
+                };
+                hresult.0
             }
         }),
         Hooks::OnDistributionRegistered => Some(quote! {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution:  *const ::wslplugins_rs::sys::WSLOfflineDistributionInformation,
-            ) -> ::windows::core::HRESULT {
+            ) -> i32 {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                if let Some(plugin) = PLUGIN.get() {
+                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
                     plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     ).into()
                 } else {
                     ::windows::Win32::Foundation::E_FAIL
-                }
+                };
+                hresult.0
             }
         }),
         Hooks::OnDistributionUnregistered => Some(quote! {
             extern "C" fn #c_method_ident(
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation,
                 distribution:  *const ::wslplugins_rs::sys::WSLOfflineDistributionInformation,
-            ) -> ::windows::core::HRESULT {
+            ) -> i32 {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                if let Some(plugin) = PLUGIN.get() {
+                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
                     plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     ).into()
                 } else {
                     ::windows::Win32::Foundation::E_FAIL
-                }
+                };
+                hresult.0
             }
         }),
     };

--- a/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
+++ b/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
@@ -16,16 +16,13 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let settings_ptr = unsafe { &*settings };
-                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
+                PLUGIN.get().map(|plugin|{
                     let result = plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         settings_ptr.as_ref(),
                     );
-                    ::wslplugins_rs::plugin::utils::consume_to_win_result(result).into()
-                } else {
-                    ::windows::Win32::Foundation::E_FAIL
-                };
-                hresult.0
+                    ::windows::core::HRESULT::from(::wslplugins_rs::plugin::utils::consume_to_win_result(result)).0
+                }).unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_FAIL)
             }
         }),
         Hooks::OnVMStopping => Some(quote! {
@@ -33,12 +30,12 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                 session: *const ::wslplugins_rs::sys::WSLSessionInformation
             ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
-                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
-                    plugin.#trait_method_ident(session_ptr.as_ref()).into()
-                } else {
-                    ::windows::Win32::Foundation::E_FAIL
-                };
-                hresult.0
+                PLUGIN.get()
+                    .map(|plugin| {
+                        let result = plugin.#trait_method_ident(session_ptr.as_ref());
+                        windows::core::HRESULT::from(result).0
+                    })
+                    .unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_FAIL)
             }
         }),
         Hooks::OnDistributionStarted => Some(quote! {
@@ -48,16 +45,13 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
+                PLUGIN.get().map(|plugin|{
                     let result = plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
                     );
-                    ::wslplugins_rs::plugin::utils::consume_to_win_result(result).into()
-                } else {
-                    ::windows::Win32::Foundation::E_FAIL
-                };
-                hresult.0
+                    windows::core::HRESULT::from(::wslplugins_rs::plugin::utils::consume_to_win_result(result)).0
+                }).unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_FAIL)
             }
         }),
         Hooks::OnDistributionStopping => Some(quote! {
@@ -67,15 +61,12 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
-                    plugin.#trait_method_ident(
+                PLUGIN.get().map(|plugin|{
+                    windows::core::HRESULT::from(plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
-                    ).into()
-                } else {
-                    ::windows::Win32::Foundation::E_FAIL
-                };
-                hresult.0
+                    )).0
+                }).unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_FAIL)
             }
         }),
         Hooks::OnDistributionRegistered => Some(quote! {
@@ -85,15 +76,12 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
-                    plugin.#trait_method_ident(
+                PLUGIN.get().map(|plugin|{
+                    windows::core::HRESULT::from(plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
-                    ).into()
-                } else {
-                    ::windows::Win32::Foundation::E_FAIL
-                };
-                hresult.0
+                    )).0
+                }).unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation)
             }
         }),
         Hooks::OnDistributionUnregistered => Some(quote! {
@@ -103,15 +91,12 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
             ) -> ::wslplugins_rs::sys::windows_sys::core::HRESULT {
                 let session_ptr = unsafe { &*session };
                 let distribution_ptr = unsafe { &*distribution };
-                let hresult: ::windows::core::HRESULT = if let Some(plugin) = PLUGIN.get() {
-                    plugin.#trait_method_ident(
+                PLUGIN.get().map(|plugin|{
+                    windows::core::HRESULT::from(plugin.#trait_method_ident(
                         session_ptr.as_ref(),
                         distribution_ptr.as_ref(),
-                    ).into()
-                } else {
-                    ::windows::Win32::Foundation::E_FAIL
-                };
-                hresult.0
+                    )).0
+                }).unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation)
             }
         }),
     };

--- a/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
+++ b/wslplugins-macro-core/src/generator/c_funcs_tokens.rs
@@ -21,7 +21,7 @@ pub(super) fn get_c_func_tokens(hook: Hooks) -> Result<Option<TokenStream>> {
                         session_ptr.as_ref(),
                         settings_ptr.as_ref(),
                     );
-                    ::windows::core::HRESULT::from(::wslplugins_rs::plugin::utils::consume_to_win_result(result)).0
+                    ::wslplugins_rs::windows_core::HRESULT::from(::wslplugins_rs::plugin::utils::consume_to_win_result(result)).0
                 }).unwrap_or(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_FAIL)
             }
         }),

--- a/wslplugins-macro-core/src/generator/hook_field_mapping.rs
+++ b/wslplugins-macro-core/src/generator/hook_field_mapping.rs
@@ -112,7 +112,7 @@ fn generate_entry_point(imp: &ParsedImpl, version: &RequiredVersion) -> Result<T
         ) -> ::wslplugins_rs::windows_core::Result<()> {
             let plugin: #static_plugin_type = ::wslplugins_rs::plugin::create_plugin_with_required_version(api, #major, #minor, #revision)?;
             #(#hook_set)*
-            PLUGIN.set(plugin).map_err(|_| ::wslplugins_rs::windows_core::Error::from(::windows::Win32::Foundation::E_ABORT))
+            PLUGIN.set(plugin).map_err(|_| ::wslplugins_rs::windows_core::Error::from(::wslplugins_rs::windows_core::HRESULT(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_ABORT)))
         }
     })
 }

--- a/wslplugins-macro-core/src/generator/hook_field_mapping.rs
+++ b/wslplugins-macro-core/src/generator/hook_field_mapping.rs
@@ -98,7 +98,7 @@ fn generate_entry_point(imp: &ParsedImpl, version: &RequiredVersion) -> Result<T
         pub unsafe extern "C" fn WSLPluginAPIV1_EntryPoint(
             api: *const ::wslplugins_rs::sys::WSLPluginAPIV1,
             hooks: *mut ::wslplugins_rs::sys::WSLPluginHooksV1,
-        ) -> ::windows::core::HRESULT {
+        ) -> ::wslplugins_rs::windows_core::HRESULT {
             unsafe {
                 let api_ref: &'static ::wslplugins_rs::sys::WSLPluginAPIV1 = unsafe { &*api};
                 let #hooks_ref_name: &mut ::wslplugins_rs::sys::WSLPluginHooksV1 = unsafe{ &mut *hooks };
@@ -109,10 +109,10 @@ fn generate_entry_point(imp: &ParsedImpl, version: &RequiredVersion) -> Result<T
         fn create_plugin(
             api: &'static ::wslplugins_rs::sys::WSLPluginAPIV1,
             hooks_ref: &mut ::wslplugins_rs::sys::WSLPluginHooksV1,
-        ) -> ::windows::core::Result<()> {
+        ) -> ::wslplugins_rs::windows_core::Result<()> {
             let plugin: #static_plugin_type = ::wslplugins_rs::plugin::create_plugin_with_required_version(api, #major, #minor, #revision)?;
             #(#hook_set)*
-            PLUGIN.set(plugin).map_err(|_| ::windows::core::Error::from(::windows::Win32::Foundation::E_ABORT))
+            PLUGIN.set(plugin).map_err(|_| ::wslplugins_rs::windows_core::Error::from(::windows::Win32::Foundation::E_ABORT))
         }
     })
 }

--- a/wslplugins-rs/Cargo.toml
+++ b/wslplugins-rs/Cargo.toml
@@ -7,16 +7,9 @@ repository.workspace = true
 description.workspace = true
 edition = "2021"
 
-[dependencies.windows]
-workspace = true
-features = [
-  "Win32_Foundation",
-  "Win32_System",
-  "Win32_Security",
-  "Win32_Networking_WinSock",
-]
 
 [dependencies]
+windows-core = "0.61.2"
 bitflags = { version = ">0.1.0", optional = true }
 enumflags2 = { version = ">0.5", optional = true }
 flagset = { version = ">0.1.0", optional = true }

--- a/wslplugins-rs/Cargo.toml
+++ b/wslplugins-rs/Cargo.toml
@@ -9,7 +9,12 @@ edition = "2021"
 
 [dependencies.windows]
 workspace = true
-features = ["Win32_Foundation", "Win32_System", "Win32_Networking_WinSock"]
+features = [
+  "Win32_Foundation",
+  "Win32_System",
+  "Win32_Security",
+  "Win32_Networking_WinSock",
+]
 
 [dependencies]
 bitflags = { version = ">0.1.0", optional = true }

--- a/wslplugins-rs/src/api/api_v1.rs
+++ b/wslplugins-rs/src/api/api_v1.rs
@@ -11,15 +11,14 @@ use log_instrument::instrument;
 use std::ffi::{CString, OsStr};
 use std::fmt::Debug;
 use std::iter::once;
-use std::mem::MaybeUninit;
+use std::mem::{self, MaybeUninit};
 use std::net::TcpStream;
 use std::os::windows::io::FromRawSocket;
 use std::os::windows::raw::SOCKET;
 use std::path::Path;
 use typed_path::Utf8UnixPath;
 use widestring::U16CString;
-use windows::core::{Result as WinResult, BOOL, GUID, PCSTR, PCWSTR};
-use windows::Win32::Networking::WinSock::SOCKET as WinSocket;
+use windows::core::{Result as WinResult, BOOL, GUID, HRESULT};
 
 use wslpluginapi_sys::WSLPluginAPIV1;
 
@@ -104,13 +103,13 @@ impl ApiV1 {
         let result = unsafe {
             self.0.MountFolder.unwrap_unchecked()(
                 session.id(),
-                PCWSTR::from_raw(encoded_windows_path.as_ptr()),
-                PCWSTR::from_raw(encoded_linux_path.as_ptr()),
-                BOOL::from(read_only),
-                PCWSTR::from_raw(encoded_name.as_ptr()),
+                encoded_windows_path.as_ptr(),
+                encoded_linux_path.as_ptr(),
+                BOOL::from(read_only).0,
+                encoded_name.as_ptr(),
             )
         };
-        result.ok()
+        HRESULT(result).ok()
     }
 
     /// Execute a program in the root namespace.
@@ -162,23 +161,23 @@ impl ApiV1 {
             .iter()
             .map(|&arg| CString::from_str_truncate(arg))
             .collect();
-        let mut args_ptrs: Vec<PCSTR> = c_args
+        let mut args_ptrs: Vec<*const u8> = c_args
             .iter()
-            .map(|arg| PCSTR::from_raw(arg.as_ptr() as *const u8))
-            .chain(Some(PCSTR::null()))
+            .map(|arg| arg.as_ptr() as *const u8)
+            .chain(once(std::ptr::null::<u8>()))
             .collect();
         let args_ptr = args_ptrs.as_mut_ptr();
-        let mut socket = MaybeUninit::<WinSocket>::uninit();
+        let mut socket = MaybeUninit::<usize>::uninit();
         let stream = unsafe {
-            self.0.ExecuteBinary.unwrap_unchecked()(
+            HRESULT(self.0.ExecuteBinary.unwrap_unchecked()(
                 session.id(),
-                PCSTR::from_raw(c_path.as_ptr()),
+                c_path.as_ptr(),
                 args_ptr,
                 socket.as_mut_ptr(),
-            )
+            ))
             .ok()?;
             let socket = socket.assume_init();
-            TcpStream::from_raw_socket(socket.0 as SOCKET)
+            TcpStream::from_raw_socket(socket as SOCKET)
         };
         Ok(stream)
     }
@@ -187,9 +186,7 @@ impl ApiV1 {
     #[cfg_attr(feature = "log-instrument", instrument)]
     pub(crate) fn plugin_error(&self, error: &OsStr) -> WinResult<()> {
         let error_utf16 = U16CString::from_os_str_truncate(error);
-        unsafe {
-            self.0.PluginError.unwrap_unchecked()(PCWSTR::from_raw(error_utf16.as_ptr())).ok()
-        }
+        HRESULT(unsafe { self.0.PluginError.unwrap_unchecked()(error_utf16.as_ptr()) }).ok()
     }
 
     /// Execute a program in a user distribution
@@ -241,29 +238,29 @@ impl ApiV1 {
             .copied()
             .chain(once(0))
             .collect();
-        let path_ptr = PCSTR::from_raw(c_path.as_ptr());
+        let path_ptr = c_path.as_ptr();
         let c_args: Vec<CString> = args
             .iter()
             .map(|&arg| CString::from_str_truncate(arg))
             .collect();
-        let mut args_ptrs: Vec<PCSTR> = c_args
+        let mut args_ptrs: Vec<_> = c_args
             .iter()
-            .map(|arg| PCSTR::from_raw(arg.as_ptr() as *const u8))
-            .chain(Some(PCSTR::null()))
+            .map(|arg| arg.as_ptr() as *const u8)
+            .chain(once(std::ptr::null()))
             .collect();
         let args_ptr = args_ptrs.as_mut_ptr();
-        let mut socket = MaybeUninit::<WinSocket>::uninit();
+        let mut socket = MaybeUninit::<usize>::uninit();
         let stream = unsafe {
-            self.0.ExecuteBinaryInDistribution.unwrap_unchecked()(
+            HRESULT(self.0.ExecuteBinaryInDistribution.unwrap_unchecked()(
                 session.id(),
-                &distribution_id,
+                &mem::transmute(distribution_id),
                 path_ptr,
                 args_ptr,
                 socket.as_mut_ptr(),
-            )
+            ))
             .ok()?;
             let socket = socket.assume_init();
-            TcpStream::from_raw_socket(socket.0 as SOCKET)
+            TcpStream::from_raw_socket(socket as SOCKET)
         };
         Ok(stream)
     }

--- a/wslplugins-rs/src/api/api_v1.rs
+++ b/wslplugins-rs/src/api/api_v1.rs
@@ -129,7 +129,7 @@ impl ApiV1 {
     /// - **Standard Output**: Data output by the process will be readable from the stream.
     ///
     /// # Errors
-    /// This method can return the following a [`windows::core::Error`]: If the underlying Windows API call fails.
+    /// This method can return the following a [windows_core::Error]: If the underlying Windows API call fails.
     ///
     /// # Example
     /// ```rust,ignore

--- a/wslplugins-rs/src/api/api_v1.rs
+++ b/wslplugins-rs/src/api/api_v1.rs
@@ -11,7 +11,7 @@ use log_instrument::instrument;
 use std::ffi::{CString, OsStr};
 use std::fmt::Debug;
 use std::iter::once;
-use std::mem::{self, MaybeUninit};
+use std::mem::MaybeUninit;
 use std::net::TcpStream;
 use std::os::windows::io::FromRawSocket;
 use std::os::windows::raw::SOCKET;
@@ -253,7 +253,8 @@ impl ApiV1 {
         let stream = unsafe {
             HRESULT(self.0.ExecuteBinaryInDistribution.unwrap_unchecked()(
                 session.id(),
-                &mem::transmute(distribution_id),
+                (&distribution_id) as *const GUID
+                    as *const wslpluginapi_sys::windows_sys::core::GUID,
                 path_ptr,
                 args_ptr,
                 socket.as_mut_ptr(),

--- a/wslplugins-rs/src/api/api_v1.rs
+++ b/wslplugins-rs/src/api/api_v1.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use typed_path::Utf8UnixPath;
 use widestring::U16CString;
 use windows::core::{Result as WinResult, BOOL, GUID, HRESULT};
+use wslpluginapi_sys::windows_sys::Win32::Networking::WinSock::SOCKET as WinSocket;
 
 use wslpluginapi_sys::WSLPluginAPIV1;
 
@@ -167,7 +168,7 @@ impl ApiV1 {
             .chain(once(std::ptr::null::<u8>()))
             .collect();
         let args_ptr = args_ptrs.as_mut_ptr();
-        let mut socket = MaybeUninit::<usize>::uninit();
+        let mut socket = MaybeUninit::<WinSocket>::uninit();
         let stream = unsafe {
             HRESULT(self.0.ExecuteBinary.unwrap_unchecked()(
                 session.id(),
@@ -249,7 +250,7 @@ impl ApiV1 {
             .chain(once(std::ptr::null()))
             .collect();
         let args_ptr = args_ptrs.as_mut_ptr();
-        let mut socket = MaybeUninit::<usize>::uninit();
+        let mut socket = MaybeUninit::<WinSocket>::uninit();
         let stream = unsafe {
             HRESULT(self.0.ExecuteBinaryInDistribution.unwrap_unchecked()(
                 session.id(),

--- a/wslplugins-rs/src/api/api_v1.rs
+++ b/wslplugins-rs/src/api/api_v1.rs
@@ -18,7 +18,7 @@ use std::os::windows::raw::SOCKET;
 use std::path::Path;
 use typed_path::Utf8UnixPath;
 use widestring::U16CString;
-use windows::core::{Result as WinResult, BOOL, GUID, HRESULT};
+use windows_core::{Result as WinResult, GUID, HRESULT};
 use wslpluginapi_sys::windows_sys::Win32::Networking::WinSock::SOCKET as WinSocket;
 
 use wslpluginapi_sys::WSLPluginAPIV1;
@@ -106,7 +106,7 @@ impl ApiV1 {
                 session.id(),
                 encoded_windows_path.as_ptr(),
                 encoded_linux_path.as_ptr(),
-                BOOL::from(read_only).0,
+                read_only as i32,
                 encoded_name.as_ptr(),
             )
         };

--- a/wslplugins-rs/src/api/errors.rs
+++ b/wslplugins-rs/src/api/errors.rs
@@ -52,7 +52,7 @@ impl From<Error> for WinError {
     /// A `WinError` representing the error.
     fn from(value: Error) -> Self {
         match value {
-            Error::RequiresUpdate { .. } => WSL_E_PLUGIN_REQUIRES_UPDATE.into(),
+            Error::RequiresUpdate { .. } => HRESULT(WSL_E_PLUGIN_REQUIRES_UPDATE).into(),
             Error::WinError(error) => error,
         }
     }

--- a/wslplugins-rs/src/api/errors.rs
+++ b/wslplugins-rs/src/api/errors.rs
@@ -7,7 +7,7 @@
 use thiserror::Error;
 pub mod require_update_error;
 pub use require_update_error::Error as RequireUpdateError;
-use windows::core::{Error as WinError, HRESULT};
+use windows_core::{Error as WinError, HRESULT};
 use wslpluginapi_sys::WSL_E_PLUGIN_REQUIRES_UPDATE;
 
 /// A comprehensive error type for WSL plugins.

--- a/wslplugins-rs/src/api/errors/require_update_error.rs
+++ b/wslplugins-rs/src/api/errors/require_update_error.rs
@@ -51,7 +51,7 @@ impl From<Error> for HRESULT {
     /// # Returns
     /// - `[WSL_E_PLUGIN_REQUIRES_UPDATE]: Indicates the WSL version is insufficient for the plugin.
     fn from(_: Error) -> Self {
-        WSL_E_PLUGIN_REQUIRES_UPDATE
+        HRESULT(WSL_E_PLUGIN_REQUIRES_UPDATE)
     }
 }
 

--- a/wslplugins-rs/src/api/errors/require_update_error.rs
+++ b/wslplugins-rs/src/api/errors/require_update_error.rs
@@ -6,7 +6,7 @@
 
 use crate::WSLVersion;
 use thiserror::Error;
-use windows::core::HRESULT;
+use windows_core::HRESULT;
 use wslpluginapi_sys::WSL_E_PLUGIN_REQUIRES_UPDATE;
 
 /// Represents an error when the current WSL version is unsupported.

--- a/wslplugins-rs/src/core_distribution_information.rs
+++ b/wslplugins-rs/src/core_distribution_information.rs
@@ -11,7 +11,7 @@
 
 use crate::api::errors::require_update_error::Result;
 use std::ffi::OsString;
-use windows::core::GUID;
+use windows_core::GUID;
 
 /// A trait representing the core information of a WSL distribution.
 ///

--- a/wslplugins-rs/src/distribution_information.rs
+++ b/wslplugins-rs/src/distribution_information.rs
@@ -25,7 +25,7 @@ use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::mem;
 use std::os::windows::ffi::OsStringExt;
-use windows::core::{GUID, PCWSTR};
+use windows_core::{GUID, PCWSTR};
 
 /// Represents detailed information about a WSL distribution.
 ///

--- a/wslplugins-rs/src/distribution_information.rs
+++ b/wslplugins-rs/src/distribution_information.rs
@@ -91,7 +91,7 @@ impl DistributionInformation {
 
 impl CoreDistributionInformation for DistributionInformation {
     fn id(&self) -> GUID {
-        unsafe { mem::transmute(self.0.Id) }
+        unsafe { mem::transmute_copy(&self.0.Id) }
     }
 
     fn name(&self) -> OsString {

--- a/wslplugins-rs/src/distribution_information.rs
+++ b/wslplugins-rs/src/distribution_information.rs
@@ -12,7 +12,6 @@
 //! - Process ID (PID) of the init process (requires API version 2.0.5 or higher)
 //! - PID namespace
 
-extern crate wslpluginapi_sys;
 #[cfg(doc)]
 use crate::api::errors::require_update_error::Error;
 use crate::api::{
@@ -24,8 +23,9 @@ use crate::WSLVersion;
 use std::ffi::OsString;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
+use std::mem;
 use std::os::windows::ffi::OsStringExt;
-use windows::core::GUID;
+use windows::core::{GUID, PCWSTR};
 
 /// Represents detailed information about a WSL distribution.
 ///
@@ -91,11 +91,11 @@ impl DistributionInformation {
 
 impl CoreDistributionInformation for DistributionInformation {
     fn id(&self) -> GUID {
-        self.0.Id
+        unsafe { mem::transmute(self.0.Id) }
     }
 
     fn name(&self) -> OsString {
-        unsafe { OsString::from_wide(self.0.Name.as_wide()) }
+        unsafe { OsString::from_wide(PCWSTR::from_raw(self.0.Name).as_wide()) }
     }
 
     fn package_family_name(&self) -> Option<OsString> {
@@ -104,7 +104,7 @@ impl CoreDistributionInformation for DistributionInformation {
             if ptr.is_null() {
                 None
             } else {
-                Some(OsString::from_wide(ptr.as_wide()))
+                Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide()))
             }
         }
     }
@@ -119,7 +119,7 @@ impl CoreDistributionInformation for DistributionInformation {
             if ptr.is_null() {
                 Ok(None)
             } else {
-                Ok(Some(OsString::from_wide(ptr.as_wide())))
+                Ok(Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide())))
             }
         }
     }
@@ -134,7 +134,7 @@ impl CoreDistributionInformation for DistributionInformation {
             if ptr.is_null() {
                 Ok(None)
             } else {
-                Ok(Some(OsString::from_wide(ptr.as_wide())))
+                Ok(Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide())))
             }
         }
     }
@@ -159,7 +159,14 @@ impl Hash for DistributionInformation {
 
 impl Display for DistributionInformation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unsafe { write!(f, "{:} {{{:?}}}", self.0.Name.display(), self.0.Id) }
+        unsafe {
+            write!(
+                f,
+                "{:} {{{:?}}}",
+                PCWSTR::from_raw(self.0.Name).display(),
+                self.id()
+            )
+        }
     }
 }
 

--- a/wslplugins-rs/src/lib.rs
+++ b/wslplugins-rs/src/lib.rs
@@ -53,6 +53,7 @@ pub use wsl_user_configuration::WSLUserConfiguration;
 mod wsl_vm_creation_settings;
 #[cfg(doc)]
 use crate::plugin::WSLPluginV1;
+pub extern crate typed_path;
 /// Tools and utilities for creating custom WSL plugins.
 pub mod plugin;
 

--- a/wslplugins-rs/src/lib.rs
+++ b/wslplugins-rs/src/lib.rs
@@ -23,7 +23,7 @@
 //! ```rust
 //! #[cfg(feature = "macro")]
 //! use wslplugins_rs::{plugin::WSLPluginV1, WSLContext};
-//! use windows::core::Result as WinResult;
+//! use windows_core::Result as WinResult;
 //! use wslplugins_rs::wsl_plugin_v1;
 //! pub(crate) struct MyPlugin {
 //!   context: &'static WSLContext,
@@ -42,6 +42,7 @@ pub mod api;
 // Internal modules for managing specific WSL features.
 mod core_distribution_information;
 pub(crate) mod cstring_ext;
+pub extern crate windows_core;
 mod distribution_information;
 mod offline_distribution_information;
 mod utils;

--- a/wslplugins-rs/src/offline_distribution_information.rs
+++ b/wslplugins-rs/src/offline_distribution_information.rs
@@ -15,9 +15,10 @@ use std::{
     ffi::OsString,
     fmt::{Debug, Display},
     hash::Hash,
+    mem,
     os::windows::ffi::OsStringExt,
 };
-use windows::core::GUID;
+use windows::core::{GUID, PCWSTR};
 
 /// A wrapper around `WslOfflineDistributionInformation` providing a safe interface.
 ///
@@ -56,12 +57,12 @@ impl AsRef<OfflineDistributionInformation> for wslpluginapi_sys::WslOfflineDistr
 impl CoreDistributionInformation for OfflineDistributionInformation {
     /// Retrieves the [GUID] of the offline distribution.
     fn id(&self) -> GUID {
-        self.0.Id
+        unsafe { mem::transmute(self.0.Id) }
     }
 
     /// Retrieves the name of the offline distribution as an [OsString].
     fn name(&self) -> OsString {
-        unsafe { OsString::from_wide(self.0.Name.as_wide()) }
+        unsafe { OsString::from_wide(PCWSTR::from_raw(self.0.Name).as_wide()) }
     }
 
     /// Retrieves the package family name of the offline distribution, if available.
@@ -71,7 +72,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
     /// - `None`: If the package family name is null or empty.
     fn package_family_name(&self) -> Option<OsString> {
         unsafe {
-            let ptr = self.0.PackageFamilyName;
+            let ptr = PCWSTR::from_raw(self.0.PackageFamilyName);
             if ptr.is_null() || ptr.is_empty() {
                 None
             } else {
@@ -86,7 +87,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
             &WSLVersion::new(2, 4, 4),
         )?;
         unsafe {
-            let ptr = self.0.Flavor;
+            let ptr = PCWSTR::from_raw(self.0.Flavor);
             if ptr.is_null() || ptr.is_empty() {
                 Ok(None)
             } else {
@@ -101,7 +102,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
             &WSLVersion::new(2, 4, 4),
         )?;
         unsafe {
-            let ptr = self.0.Flavor;
+            let ptr = PCWSTR::from_raw(self.0.Flavor);
             if ptr.is_null() || ptr.is_empty() {
                 Ok(None)
             } else {
@@ -130,7 +131,14 @@ impl Hash for OfflineDistributionInformation {
 
 impl Display for OfflineDistributionInformation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unsafe { write!(f, "{:} {{{:?}}}", self.0.Name.display(), self.0.Id) }
+        unsafe {
+            write!(
+                f,
+                "{:} {{{:?}}}",
+                PCWSTR::from_raw(self.0.Name).display(),
+                self.id()
+            )
+        }
     }
 }
 

--- a/wslplugins-rs/src/offline_distribution_information.rs
+++ b/wslplugins-rs/src/offline_distribution_information.rs
@@ -57,7 +57,7 @@ impl AsRef<OfflineDistributionInformation> for wslpluginapi_sys::WslOfflineDistr
 impl CoreDistributionInformation for OfflineDistributionInformation {
     /// Retrieves the [GUID] of the offline distribution.
     fn id(&self) -> GUID {
-        unsafe { mem::transmute(self.0.Id) }
+        unsafe { mem::transmute_copy(&self.0.Id) }
     }
 
     /// Retrieves the name of the offline distribution as an [OsString].

--- a/wslplugins-rs/src/offline_distribution_information.rs
+++ b/wslplugins-rs/src/offline_distribution_information.rs
@@ -18,7 +18,7 @@ use std::{
     mem,
     os::windows::ffi::OsStringExt,
 };
-use windows::core::{GUID, PCWSTR};
+use windows_core::{GUID, PCWSTR};
 
 /// A wrapper around `WslOfflineDistributionInformation` providing a safe interface.
 ///

--- a/wslplugins-rs/src/plugin/error.rs
+++ b/wslplugins-rs/src/plugin/error.rs
@@ -10,7 +10,7 @@ use log::debug;
 use std::ffi::{OsStr, OsString};
 use std::num::NonZeroI32;
 use thiserror::Error;
-use windows::core::{Error as WinError, HRESULT};
+use windows_core::{Error as WinError, HRESULT};
 
 /// A specialized result type for operations that may return a WSL plugin error.
 ///

--- a/wslplugins-rs/src/plugin/utils.rs
+++ b/wslplugins-rs/src/plugin/utils.rs
@@ -4,7 +4,7 @@
 //! enabling smooth integration with the WSL Plugin API.
 
 use windows::{
-    core::{Error as WinError, Result as WinResult},
+    core::{Error as WinError, Result as WinResult, HRESULT},
     Win32::Foundation::ERROR_ALREADY_INITIALIZED,
 };
 use wslpluginapi_sys::WSLPluginAPIV1;
@@ -47,8 +47,13 @@ pub fn create_plugin_with_required_version<T: WSLPluginV1>(
     required_revision: u32,
 ) -> WinResult<T> {
     unsafe {
-        wslpluginapi_sys::require_version(required_major, required_minor, required_revision, api)
-            .ok()?;
+        HRESULT(wslpluginapi_sys::require_version(
+            required_major,
+            required_minor,
+            required_revision,
+            api,
+        ))
+        .ok()?;
     }
     if let Some(context) = WSLContext::init(api.as_ref()) {
         let plugin = T::try_new(context)?;

--- a/wslplugins-rs/src/plugin/utils.rs
+++ b/wslplugins-rs/src/plugin/utils.rs
@@ -3,11 +3,8 @@
 //! This module provides utility functions for creating WSL plugins and handling results,
 //! enabling smooth integration with the WSL Plugin API.
 
-use windows::{
-    core::{Error as WinError, Result as WinResult, HRESULT},
-    Win32::Foundation::ERROR_ALREADY_INITIALIZED,
-};
-use wslpluginapi_sys::WSLPluginAPIV1;
+use windows::core::{Error as WinError, Result as WinResult, HRESULT};
+use wslpluginapi_sys::{windows_sys::Win32::Foundation::ERROR_ALREADY_INITIALIZED, WSLPluginAPIV1};
 
 use crate::WSLContext;
 
@@ -55,12 +52,11 @@ pub fn create_plugin_with_required_version<T: WSLPluginV1>(
         ))
         .ok()?;
     }
-    if let Some(context) = WSLContext::init(api.as_ref()) {
-        let plugin = T::try_new(context)?;
-        Ok(plugin)
-    } else {
-        Err(WinError::from(ERROR_ALREADY_INITIALIZED))
-    }
+    WSLContext::init(api.as_ref())
+        .ok_or(WinError::from_hresult(HRESULT::from_win32(
+            ERROR_ALREADY_INITIALIZED,
+        )))
+        .and_then(T::try_new)
 }
 
 /// Converts a generic `Result<T>` using the custom `Error` type into a `WinResult<T>`.

--- a/wslplugins-rs/src/plugin/utils.rs
+++ b/wslplugins-rs/src/plugin/utils.rs
@@ -3,7 +3,7 @@
 //! This module provides utility functions for creating WSL plugins and handling results,
 //! enabling smooth integration with the WSL Plugin API.
 
-use windows::core::{Error as WinError, Result as WinResult, HRESULT};
+use windows_core::{Error as WinError, Result as WinResult, HRESULT};
 use wslpluginapi_sys::{windows_sys::Win32::Foundation::ERROR_ALREADY_INITIALIZED, WSLPluginAPIV1};
 
 use crate::WSLContext;

--- a/wslplugins-rs/src/plugin/utils.rs
+++ b/wslplugins-rs/src/plugin/utils.rs
@@ -63,7 +63,7 @@ pub fn create_plugin_with_required_version<T: WSLPluginV1>(
 ///
 /// This function simplifies the interoperability between the custom error handling
 /// in the WSL plugin system and the Windows error system by mapping the plugin [Error]
-/// into a [windows::core::Error] using the `consume_error_message_unwrap` method.
+/// into a [windows_core::Error] using the `consume_error_message_unwrap` method.
 ///
 /// # Arguments
 /// - `result`: A [`Result<T>`] using the custom [Error] type defined in this crate.
@@ -71,13 +71,13 @@ pub fn create_plugin_with_required_version<T: WSLPluginV1>(
 /// # Returns
 /// A `WinResult<T>` where:
 /// - `Ok(value)` contains the successful result `T`.
-/// - `Err(error)` contains a [windows::core::Error] converted from the plugin [Error].
+/// - `Err(error)` contains a [windows_core::Error] converted from the plugin [Error].
 ///
 /// # Behavior
 /// - If the `result` is `Ok`, it is returned as-is.
 /// - If the `result` is `Err`, the error is consumed
 ///   and sent to WSL and is then
-///   converted into a [windows::core::Error].
+///   converted into a [windows_core::Error].
 ///
 /// # Usage
 /// This utility is intended to facilitate the transition between idiomatic Rust

--- a/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
+++ b/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
@@ -5,15 +5,14 @@
 //! for managing the state of the WSL VM, distributions, and related settings.
 
 use super::error::Result;
-use crate::WSLContext;
 use crate::{
     distribution_information::DistributionInformation,
     offline_distribution_information::OfflineDistributionInformation,
     wsl_session_information::WSLSessionInformation,
-    wsl_vm_creation_settings::WSLVmCreationSettings,
+    wsl_vm_creation_settings::WSLVmCreationSettings, WSLContext,
 };
 use std::marker::Sized;
-use windows::core::Result as WinResult;
+use windows_core::Result as WinResult;
 
 /// Trait defining synchronous notifications sent to the plugin.
 ///
@@ -27,7 +26,7 @@ use windows::core::Result as WinResult;
 /// # Example
 /// ```rust
 /// use wslplugins_rs::{plugin::{WSLPluginV1, Result}, WSLContext, WSLSessionInformation, WSLVmCreationSettings};
-/// use windows::core::Result as WinResult;
+/// use wslplugins_rs::windows_core::Result as WinResult;
 ///
 /// struct MyPlugin;
 ///

--- a/wslplugins-rs/src/wsl_session_information.rs
+++ b/wslplugins-rs/src/wsl_session_information.rs
@@ -27,6 +27,9 @@ impl WSLSessionInformation {
     ///
     /// # Returns
     /// A [HANDLE] representing the user token.
+    /// # Safety
+    /// This function returns a raw handle to the user token.
+    /// The handle should be used only during the life of the session and must not be closed
     pub unsafe fn user_token(&self) -> HANDLE {
         self.0.UserToken
     }
@@ -35,6 +38,9 @@ impl WSLSessionInformation {
     ///
     /// # Returns
     /// A [PSID] representing the user SID.
+    /// # Safety
+    /// This function returns a raw pointer to the user SID.
+    /// This pointer should be used only during the life of the session and must not be freed or modified.
     pub unsafe fn user_sid(&self) -> PSID {
         self.0.UserSid
     }

--- a/wslplugins-rs/src/wsl_session_information.rs
+++ b/wslplugins-rs/src/wsl_session_information.rs
@@ -5,9 +5,8 @@
 
 extern crate wslpluginapi_sys;
 use core::hash;
-use std::fmt;
-use windows::Win32::Foundation::*;
-use windows::Win32::Security::PSID;
+use std::{fmt, os::windows::raw::HANDLE};
+use wslpluginapi_sys::windows_sys::Win32::Security::PSID;
 
 /// Represents session information for a WSL instance.
 ///
@@ -28,16 +27,16 @@ impl WSLSessionInformation {
     ///
     /// # Returns
     /// A [HANDLE] representing the user token.
-    pub fn user_token(&self) -> HANDLE {
-        HANDLE(self.0.UserToken)
+    pub unsafe fn user_token(&self) -> HANDLE {
+        self.0.UserToken
     }
 
     /// Retrieves the user SID (security identifier) for the session.
     ///
     /// # Returns
     /// A [PSID] representing the user SID.
-    pub fn user_sid(&self) -> PSID {
-        PSID(self.0.UserSid)
+    pub unsafe fn user_sid(&self) -> PSID {
+        self.0.UserSid
     }
 }
 

--- a/wslplugins-rs/src/wsl_session_information.rs
+++ b/wslplugins-rs/src/wsl_session_information.rs
@@ -29,7 +29,7 @@ impl WSLSessionInformation {
     /// # Returns
     /// A [HANDLE] representing the user token.
     pub fn user_token(&self) -> HANDLE {
-        self.0.UserToken
+        HANDLE(self.0.UserToken)
     }
 
     /// Retrieves the user SID (security identifier) for the session.
@@ -37,7 +37,7 @@ impl WSLSessionInformation {
     /// # Returns
     /// A [PSID] representing the user SID.
     pub fn user_sid(&self) -> PSID {
-        self.0.UserSid
+        PSID(self.0.UserSid)
     }
 }
 


### PR DESCRIPTION
- **Implement windows-sys adaptation**
- **Fix for GUID and HRESULT**
- **Use directly Socket from windows-sys**
- **Remove windows dependency except core**
- **Use windows_core instead of windows in the lib and export it**
- **Fix missing safety message**
- **Add extern crate for typed_path**
- **Target develop branch for wslpluginapi-sys**
