### PR TITLE
Example/simplify logfile creation in minimal

### DIFF
--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::File;
+use std::io::prelude::*;
 use windows::Win32::Foundation::{E_ABORT, E_FAIL};
 use wslplugins_rs::prelude::*;
 
@@ -13,12 +13,8 @@ pub(crate) struct Plugin {
 #[wsl_plugin_v1(2, 1, 3)]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
-        let log_file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open("C:\\wsl-plugin-demo.txt")
-            .map_err(|_| WinError::from(E_ABORT))?;
+        let log_file =
+            File::create("C:\\wsl-plugin-demo.txt").map_err(|_| WinError::from(E_ABORT))?;
         writeln!(
             &log_file,
             "Plugin loaded. WSL version: {}",


### PR DESCRIPTION
## Summary

Simplify logfile creation in minimal

## Changes

Use `File::Create` instead of `OpenOption` for the same result

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [ ] Documentation
- [X] Examples : minimal
- [ ] CI / release workflow

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [X] Relevant manual testing completed

## WSL / Windows Notes

- Does this affect plugin loading, signing, registration, or Windows-only behavior?
- If yes, describe what was tested and in which environment.

## Checklist

- [X] Tests added or updated when relevant: NA
- [X] Documentation updated when relevant: NA
- [X] Examples updated when relevant: NA
- [X] No unrelated changes included: NA
