### PR TITLE
Create unpackaged-distro-blacklist-policy example

### DIFF
--- a/examples/unpackaged-distro-blacklist-policy/Cargo.toml
+++ b/examples/unpackaged-distro-blacklist-policy/Cargo.toml
@@ -5,7 +5,8 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description.workspace = true
+publish = false
+readme = "README.md"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/unpackaged-distro-blacklist-policy/Cargo.toml
+++ b/examples/unpackaged-distro-blacklist-policy/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "unpackaged-distro-blacklist-policy"
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
+  "macro",
+  "bitflags",
+  "tracing",
+], version = "0.1.0-beta.2" }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
+
+[dependencies.windows]
+workspace = true
+features = ["Win32_Foundation"]
+
+[lints]
+workspace = true

--- a/examples/unpackaged-distro-blacklist-policy/README.md
+++ b/examples/unpackaged-distro-blacklist-policy/README.md
@@ -1,0 +1,34 @@
+# Unpackaged distro blacklist policy example
+
+This example demonstrates a WSL plugin that blocks unpackaged distributions at startup.
+
+It is intended as a reference for:
+- enforcing a simple host-side policy with [`wslplugins_rs`]
+- inspecting [`DistributionInformation`] when a distribution starts
+- returning a structured [`PluginError`] to deny an operation
+- emitting file-based diagnostics with [`tracing`]
+
+## What this example does
+
+When a distribution starts, the plugin checks its package family name:
+- if the distribution has a non-empty package family name, startup is allowed
+- if the package family name is missing or empty, startup is denied with `E_ACCESSDENIED`
+
+This makes the example useful for environments that only want to allow Store-packaged or otherwise packaged WSL distributions.
+
+## Error reporting in WSL
+
+The denial path uses [`PluginError::with_message`] to attach a human-readable message to the `E_ACCESSDENIED` error returned by the plugin.
+
+In practice, this is the part of the example that shows how to surface a policy error back to WSL so the user sees a clear explanation instead of only a raw failure code.
+
+## Logging behavior
+
+The plugin writes diagnostics to a file using [`tracing_subscriber`] and [`tracing_appender`].
+
+It supports the following environment variables:
+- `RUST_WSL_LOGLEVEL` to configure the log filter
+- `RUST_LOG` as a fallback log filter
+- `RUST_WSL_LOG_PATH` to override the default log file path
+
+If `RUST_WSL_LOG_PATH` is not set, logs are appended to `C:\wsl-unpackaged-distro-blacklist.log`.

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -65,7 +65,7 @@ impl WSLPluginV1 for Plugin {
         distribution: &DistributionInformation,
     ) -> PluginResult<()> {
         if let Some(package_familly_name) =
-            distribution.package_family_name().filter(|s| s.len() > 0)
+            distribution.package_family_name().filter(|s| !s.is_empty())
         // treat empty string as no package family name see https://github.com/mveril/wslplugins-rs/issues/44
         {
             info!(

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -1,6 +1,6 @@
-use std::ffi::OsString;
+#![doc = include_str!("../README.md")]
 
-// #![doc = include_str!("../README.md")]
+use std::ffi::OsString;
 use std::{env, fs::OpenOptions, panic};
 use tracing::{error, info, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -64,6 +64,10 @@ impl WSLPluginV1 for Plugin {
         _session: &WSLSessionInformation,
         distribution: &DistributionInformation,
     ) -> PluginResult<()> {
+        #[allow(
+            clippy::option_if_let_else,
+            reason = "Improve readability by using if let"
+        )]
         if let Some(package_familly_name) =
             distribution.package_family_name().filter(|s| !s.is_empty())
         // treat empty string as no package family name see https://github.com/mveril/wslplugins-rs/issues/44
@@ -79,7 +83,7 @@ impl WSLPluginV1 for Plugin {
             msg.push(distribution.name());
             msg.push("` is not allowed by your organization because it is not packaged.");
             warn!("{}", msg.display());
-            return Err(PluginError::with_message(E_ACCESSDENIED, &msg));
+            Err(PluginError::with_message(E_ACCESSDENIED, &msg))
         }
     }
 }

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -64,23 +64,22 @@ impl WSLPluginV1 for Plugin {
         _session: &WSLSessionInformation,
         distribution: &DistributionInformation,
     ) -> PluginResult<()> {
-        if distribution
-            .package_family_name()
-            .filter(|s| s.len() > 0) // treat empty string as no package family name see https://github.com/mveril/wslplugins-rs/issues/44
-            .is_none()
+        if let Some(package_familly_name) =
+            distribution.package_family_name().filter(|s| s.len() > 0)
+        // treat empty string as no package family name see https://github.com/mveril/wslplugins-rs/issues/44
         {
+            info!(
+                "Distribution {} started with package family name {:}",
+                distribution.name().display(),
+                package_familly_name.display()
+            );
+            Ok(())
+        } else {
             let mut msg = OsString::from("The WSL distribution `");
             msg.push(distribution.name());
             msg.push("` is not allowed by your organization because it is not packaged.");
             warn!("{}", msg.display());
             return Err(PluginError::with_message(E_ACCESSDENIED, &msg));
-        } else {
-            info!(
-                "Distribution {} started with package family name {:}",
-                distribution.name().display(),
-                distribution.package_family_name()
-            );
-            Ok(())
         }
     }
 }

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -1,0 +1,82 @@
+use std::ffi::OsString;
+
+// #![doc = include_str!("../README.md")]
+use std::{env, fs::OpenOptions, panic};
+use tracing::{error, info, warn};
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+use windows::Win32::Foundation::{E_ACCESSDENIED, E_FAIL};
+use wslplugins_rs::prelude::*;
+
+fn setup_logging() -> WinResult<()> {
+    // Read log level from environment first from RUST_WSL_LOGLEVEL
+    let log_level = EnvFilter::try_from_env("RUST_WSL_LOGLEVEL")
+        // else try default RUST_LOG
+        .or_else(|_| EnvFilter::try_from_default_env())
+        // fallback default if both fail
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
+    // Read log path from environment, default to C:\wsl-plugin.log
+    let log_path = env::var("RUST_WSL_LOG_PATH")
+        .unwrap_or_else(|_| "C:\\wsl-unpackaged-distro-blacklist.log".to_string());
+
+    // Open (or create) the log file in append mode
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|_| WinError::from(E_FAIL))?;
+
+    // Non-blocking writer so logging does not block the main thread
+    let (non_blocking, guard) = tracing_appender::non_blocking(file);
+
+    // Leak the guard so it lives for the whole process lifetime
+    Box::leak(Box::new(guard));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(log_level)
+        .with_writer(non_blocking)
+        .with_ansi(false) // log file, no ANSI colors
+        .with_span_events(FmtSpan::ACTIVE)
+        .try_init()
+        .map_err(|_| WinError::from(E_FAIL))?;
+
+    info!("Logging configured to path {}", log_path);
+    panic::set_hook(Box::new(|info| {
+        // This will be called for *every* panic before unwinding
+        error!("panic: {info}");
+    }));
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct Plugin;
+
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        setup_logging()?;
+        info!("Plugin created");
+        Ok(Self)
+    }
+
+    fn on_distribution_started(
+        &self,
+        _session: &WSLSessionInformation,
+        distribution: &DistributionInformation,
+    ) -> PluginResult<()> {
+        if distribution.package_family_name().is_none() {
+            let mut msg = OsString::from("The WSL distribution `");
+            msg.push(distribution.name());
+            msg.push("` is not allowed by your organization because it is not packaged.");
+            warn!("{}", msg.display());
+            return Err(PluginError::with_message(E_ACCESSDENIED, &msg));
+        } else {
+            info!(
+                "Distribution {} started with package family name {:?}",
+                distribution.name().display(),
+                distribution.package_family_name()
+            );
+            Ok(())
+        }
+    }
+}

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -64,7 +64,11 @@ impl WSLPluginV1 for Plugin {
         _session: &WSLSessionInformation,
         distribution: &DistributionInformation,
     ) -> PluginResult<()> {
-        if distribution.package_family_name().is_none() {
+        if distribution
+            .package_family_name()
+            .filter(|s| s.len() > 0) // treat empty string as no package family name see https://github.com/mveril/wslplugins-rs/issues/44
+            .is_none()
+        {
             let mut msg = OsString::from("The WSL distribution `");
             msg.push(distribution.name());
             msg.push("` is not allowed by your organization because it is not packaged.");
@@ -72,7 +76,7 @@ impl WSLPluginV1 for Plugin {
             return Err(PluginError::with_message(E_ACCESSDENIED, &msg));
         } else {
             info!(
-                "Distribution {} started with package family name {:?}",
+                "Distribution {} started with package family name {:}",
                 distribution.name().display(),
                 distribution.package_family_name()
             );


### PR DESCRIPTION
## Summary

- Describe the change in a few sentences.
This PR provide an example of the usage of PluginError in the context of blacklist policy
This plugin example block all unpackaged distro with a custom message

## Changes

- What was added, changed, or removed?
A new example
- Note any behavioral changes or breaking changes.

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [ ] Documentation
- [X] Examples
- [ ] CI / release workflow

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [ ] Relevant manual testing completed

## WSL / Windows Notes

- Does this affect plugin loading, signing, registration, or Windows-only behavior?
No
- If yes, describe what was tested and in which environment.

## Checklist

- [ ] Tests added or updated when relevant
- [ ] Documentation updated when relevant
- [X] Examples updated when relevant
- [ ] No unrelated changes included
