### PR TITLE
hotfix remove sys patch.crates-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mveril/wslplugins-rs"
 description = "A Rust framework for developing WSL plugins using safe and idiomatic Rust."
 
-[patch.crates-io]
-wslpluginapi-sys = { version = "0.2.0", git = "https://github.com/mveril/wslpluginapi-sys.git", branch = "release/0.2.0+2.4.4" }
-
 
 [workspace.lints.rust]
 unused = "warn"


### PR DESCRIPTION
## Summary

- Describe the change in a few sentences.
Remove unnescesarry crates.io patch for sys crate (mainly a workaroud for the nightly issue and because it's not nessescary to keep it)
- Explain the motivation or user impact.
No impact 

## Changes

Remove git patch for the sys crate

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [ ] Documentation
- [ ] Examples
- [ ] CI / release workflow

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [X] Relevant manual testing completed

## WSL / Windows Notes

- Does this affect plugin loading, signing, registration, or Windows-only behavior?
- If yes, describe what was tested and in which environment.

## Checklist

- [ ] Tests added or updated when relevant
- [ ] Documentation updated when relevant
- [ ] Examples updated when relevant
- [ ] No unrelated changes included
