### PR TITLE
Fix PackageFamilyName Flavor and Version can be not None even if it should be None 

### DIFF
--- a/crates/wslplugins-rs/src/distribution_information.rs
+++ b/crates/wslplugins-rs/src/distribution_information.rs
@@ -18,6 +18,7 @@ use crate::api::{
     errors::require_update_error::Result, utils::check_required_version_result_from_context,
 };
 use crate::core_distribution_information::CoreDistributionInformation;
+use crate::utils::opt_wide_str;
 use crate::WSLVersion;
 use crate::{UserDistributionID, WSLContext};
 use std::ffi::OsString;
@@ -108,15 +109,7 @@ impl CoreDistributionInformation for DistributionInformation {
 
     #[inline]
     fn package_family_name(&self) -> Option<OsString> {
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = self.0.PackageFamilyName;
-            if ptr.is_null() {
-                None
-            } else {
-                Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide()))
-            }
-        }
+        opt_wide_str(self.0.PackageFamilyName)
     }
 
     #[inline]
@@ -125,15 +118,7 @@ impl CoreDistributionInformation for DistributionInformation {
             WSLContext::get_current(),
             &WSLVersion::new(2, 4, 4),
         )?;
-        // SAFETY: check already inside and before by versionning
-        unsafe {
-            let ptr = self.0.Flavor;
-            if ptr.is_null() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Flavor))
     }
 
     #[inline]
@@ -142,15 +127,7 @@ impl CoreDistributionInformation for DistributionInformation {
             WSLContext::get_current(),
             &WSLVersion::new(2, 4, 4),
         )?;
-        // SAFETY: check did before by versionning.
-        unsafe {
-            let ptr = self.0.Version;
-            if ptr.is_null() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Version))
     }
 }
 

--- a/crates/wslplugins-rs/src/offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/offline_distribution_information.rs
@@ -8,6 +8,7 @@ use crate::{
         errors::require_update_error::Result, utils::check_required_version_result_from_context,
     },
     core_distribution_information::CoreDistributionInformation,
+    utils::opt_wide_str,
     UserDistributionID, WSLContext, WSLVersion,
 };
 use std::{
@@ -75,15 +76,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
     /// - `None`: If the package family name is null or empty.
     #[inline]
     fn package_family_name(&self) -> Option<OsString> {
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = PCWSTR::from_raw(self.0.PackageFamilyName);
-            if ptr.is_null() || ptr.is_empty() {
-                None
-            } else {
-                Some(OsString::from_wide(ptr.as_wide()))
-            }
-        }
+        opt_wide_str(self.0.PackageFamilyName)
     }
 
     #[inline]
@@ -93,15 +86,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
             &WSLVersion::new(2, 4, 4),
         )?;
 
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = PCWSTR::from_raw(self.0.Flavor);
-            if ptr.is_null() || ptr.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(ptr.as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Flavor))
     }
 
     #[inline]
@@ -110,15 +95,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
             WSLContext::get_current(),
             &WSLVersion::new(2, 4, 4),
         )?;
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = PCWSTR::from_raw(self.0.Version);
-            if ptr.is_null() || ptr.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(ptr.as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Version))
     }
 }
 

--- a/crates/wslplugins-rs/src/utils.rs
+++ b/crates/wslplugins-rs/src/utils.rs
@@ -9,12 +9,12 @@ pub fn test_transparence<T, U>() {
     assert_eq!(size_of::<T>(), size_of::<U>());
 }
 
-pub(crate) fn opt_wide_str(ptr: *const u16) -> Option<OsString> {
+pub fn opt_wide_str(ptr: *const u16) -> Option<OsString> {
     if ptr.is_null() {
         None
     } else {
-        // SAFETY: The caller guarantees that `ptr` is valid and points to a null-terminated wide string.
         let wide_str = PCWSTR::from_raw(ptr);
+        // SAFETY: The caller guarantees that `ptr` is valid and points to a null-terminated wide string.
         unsafe {
             let wide = wide_str.as_wide();
             if wide.is_empty() {
@@ -28,8 +28,6 @@ pub(crate) fn opt_wide_str(ptr: *const u16) -> Option<OsString> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU16;
-
     use super::*;
     use proptest::prelude::*;
     #[test]

--- a/crates/wslplugins-rs/src/utils.rs
+++ b/crates/wslplugins-rs/src/utils.rs
@@ -60,7 +60,7 @@ mod tests {
             let ptr = wide.as_ptr();
 
             let result = opt_wide_str(ptr);
-
+            #[allow(clippy::indexing_slicing, reason="Safe because we know the last element is the null terminator")]
             let expected = OsString::from_wide(&wide[..wide.len() - 1]);
 
             prop_assert_eq!(result, Some(expected));

--- a/crates/wslplugins-rs/src/utils.rs
+++ b/crates/wslplugins-rs/src/utils.rs
@@ -1,5 +1,71 @@
+use std::ffi::OsString;
+#[cfg(test)]
+use std::mem::{align_of, size_of};
+use std::os::windows::ffi::OsStringExt as _;
+use windows_core::PCWSTR;
 #[cfg(test)]
 pub fn test_transparence<T, U>() {
     assert_eq!(align_of::<T>(), align_of::<U>());
     assert_eq!(size_of::<T>(), size_of::<U>());
+}
+
+pub(crate) fn opt_wide_str(ptr: *const u16) -> Option<OsString> {
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: The caller guarantees that `ptr` is valid and points to a null-terminated wide string.
+        let wide_str = PCWSTR::from_raw(ptr);
+        unsafe {
+            let wide = wide_str.as_wide();
+            if wide.is_empty() {
+                None
+            } else {
+                Some(OsString::from_wide(wide))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU16;
+
+    use super::*;
+    use proptest::prelude::*;
+    #[test]
+    fn test_empty_as_wide_null() {
+        let ptr = std::ptr::null();
+        assert_eq!(opt_wide_str(ptr), None);
+    }
+
+    #[test]
+    fn test_empty_as_wide_empty() {
+        let wide_str = [0u16; 1];
+        assert_eq!(opt_wide_str(wide_str.as_ptr()), None);
+    }
+
+    fn null_terminated_wide() -> impl Strategy<Value = Vec<u16>> {
+        let unit = prop_oneof![(1u16..=0xD7FF), (0xE000u16..=0xFFFF),];
+
+        proptest::collection::vec(unit, 0..100).prop_map(|wide| {
+            let mut wide: Vec<u16> = items;
+            wide.push(0);
+            wide
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn test_opt_wide_str_non_empty(wide in null_terminated_wide()) {
+            prop_assume!(wide.len() > 1);
+
+            let ptr = wide.as_ptr();
+
+            let result = opt_wide_str(ptr);
+
+            let expected = OsString::from_wide(&wide[..wide.len() - 1]);
+
+            prop_assert_eq!(result, Some(expected));
+        }
+    }
 }

--- a/crates/wslplugins-rs/src/utils.rs
+++ b/crates/wslplugins-rs/src/utils.rs
@@ -46,7 +46,7 @@ mod tests {
         let unit = prop_oneof![(1u16..=0xD7FF), (0xE000u16..=0xFFFF),];
 
         proptest::collection::vec(unit, 0..100).prop_map(|wide| {
-            let mut wide: Vec<u16> = items;
+            let mut wide: Vec<u16> = wide;
             wide.push(0);
             wide
         })

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -68,10 +68,7 @@ impl WSLPluginV1 for Plugin {
             clippy::option_if_let_else,
             reason = "Improve readability by using if let"
         )]
-        if let Some(package_familly_name) =
-            distribution.package_family_name().filter(|s| !s.is_empty())
-        // treat empty string as no package family name see https://github.com/mveril/wslplugins-rs/issues/44
-        {
+        if let Some(package_familly_name) = distribution.package_family_name() {
             info!(
                 "Distribution {} started with package family name {:}",
                 distribution.name().display(),


### PR DESCRIPTION
## Summary

- Describe the change in a few sentences.
- Explain the motivation or user impact.

## Changes

This will fix the issue #44 

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [X] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [ ] Documentation
- [X] Examples
- [ ] CI / release workflow

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [X] Relevant manual testing completed

## WSL / Windows Notes

- Does this affect plugin loading, signing, registration, or Windows-only behavior?
- If yes, describe what was tested and in which environment.

## Checklist

- [X] Tests added or updated when relevant
- [X] Documentation updated when relevant
- [X] Examples updated when relevant
- [X] No unrelated changes included
