### PR TITLE
Add more derives macro for errors

### DIFF
--- a/crates/wslplugins-rs/src/api/errors.rs
+++ b/crates/wslplugins-rs/src/api/errors.rs
@@ -15,7 +15,7 @@ use wslpluginapi_sys::WSL_E_PLUGIN_REQUIRES_UPDATE;
 /// This enum encapsulates two main error categories:
 /// - Plugin-specific errors (`RequireUpdateError`).
 /// - Errors originating from Windows APIs (`WinError`).
-#[derive(Debug, Error, PartialEq, Eq, Hash)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 pub enum Error {
     /// Indicates that the current WSL version does not meet the required version.
     #[error("Require Update Error")]

--- a/crates/wslplugins-rs/src/api/errors.rs
+++ b/crates/wslplugins-rs/src/api/errors.rs
@@ -15,7 +15,7 @@ use wslpluginapi_sys::WSL_E_PLUGIN_REQUIRES_UPDATE;
 /// This enum encapsulates two main error categories:
 /// - Plugin-specific errors (`RequireUpdateError`).
 /// - Errors originating from Windows APIs (`WinError`).
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq, Hash)]
 pub enum Error {
     /// Indicates that the current WSL version does not meet the required version.
     #[error("Require Update Error")]

--- a/crates/wslplugins-rs/src/api/errors/require_update_error.rs
+++ b/crates/wslplugins-rs/src/api/errors/require_update_error.rs
@@ -16,7 +16,7 @@ use windows_core::HRESULT;
 /// # Fields
 /// - `current_version`: The current WSL version.
 /// - `required_version`: The required WSL version.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
 #[error("WSLVersion unsupported: current version {current_version}, required version {required_version}")]
 pub struct Error {
     /// The current version of WSL.

--- a/crates/wslplugins-rs/src/plugin/error.rs
+++ b/crates/wslplugins-rs/src/plugin/error.rs
@@ -24,7 +24,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// This struct encapsulates:
 /// - An error code (`HRESULT`) derived from Windows APIs.
 /// - An optional error message (`OsString`).
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 pub struct Error {
     /// The error code associated with the failure.
     code: NonZeroI32,

--- a/crates/wslplugins-rs/src/user_distribution_id/parse_error.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id/parse_error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 use windows_core::HRESULT;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ParseError {
     #[error("Windows error: HRESULT={0}")]
     Windows(HRESULT),

--- a/crates/wslplugins-rs/src/user_distribution_id/parse_error.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id/parse_error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 use windows_core::HRESULT;
 
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 pub enum ParseError {
     #[error("Windows error: HRESULT={0}")]
     Windows(HRESULT),

--- a/crates/wslplugins-rs/src/wsl_version/semver_impl.rs
+++ b/crates/wslplugins-rs/src/wsl_version/semver_impl.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 /// `WSLVersion` only models the numeric `major.minor.revision` components used
 /// by the WSL plugin API. Semantic-versioning pre-release identifiers and build
 /// metadata therefore cannot be represented and are rejected.
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SemverConversionError {
     /// The semantic version contains a pre-release identifier such as
     /// `-alpha.1`, which has no equivalent in `WSLVersion`.


### PR DESCRIPTION
## Summary

- Add more convenient API for errors

## Changes

Add API like `Clone` `PartialEq` `Eq`  for all errors

## Components Touched

- [X] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [ ] Documentation
- [ ] Examples
- [ ] CI / release workflow

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [X] Relevant manual testing completed

## WSL / Windows Notes

- Does this affect plugin loading, signing, registration, or Windows-only behavior? No
- If yes, describe what was tested and in which environment.

## Checklist

- [X] Tests added or updated when relevant
- [X] Documentation updated when relevant
- [X] Examples updated when relevant
- [X] No unrelated changes included
