### PR TITLE
Release 0.1.0 beta.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ smallvec = "1"
 
 [workspace.package]
 authors = ["Mickaël Véril <mika.veril@wanadoo.fr>"]
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 readme = "README.md"
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the crate with the `macro` feature:
 
 ```toml
 [dependencies]
-wslplugins-rs = { version = "0.1.0-beta.2", features = ["macro"] }
+wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
 ```
 
 Then implement a plugin:

--- a/crates/wslplugins-macro-tests/Cargo.toml
+++ b/crates/wslplugins-macro-tests/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 wslplugins-rs = { path = "../wslplugins-rs", features = [
   "macro",
-], version = "0.1.0-beta.2" }
+], version = "0.1.0-beta.3" }
 wslpluginapi-sys.workspace = true
 
 [dependencies.windows]

--- a/crates/wslplugins-macro-tests/tests/ui/success.rs
+++ b/crates/wslplugins-macro-tests/tests/ui/success.rs
@@ -27,7 +27,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_started(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> Result<()> {
         println!(
             "Distribution started. Sessionid= {:}, Id={:?} Name={:}, Package={}, PidNs={}, InitPid={}",
@@ -49,7 +49,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_stopping(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> WinResult<()> {
         println!(
             "Distribution Stopping. SessionId={}, Id={:?} name={}, package={}, PidNs={}, InitPid={}",

--- a/crates/wslplugins-macro/Cargo.toml
+++ b/crates/wslplugins-macro/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::windows-apis", "api-bindings", "virtualization"]
 proc-macro = true
 
 [dependencies]
-wslplugins-macro-core = { path = "../wslplugins-macro-core", version = "0.1.0-beta.2"}
+wslplugins-macro-core = { path = "../wslplugins-macro-core", version = "0.1.0-beta.3"}
 syn = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -23,11 +23,7 @@ wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0
 wslpluginapi-sys.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }
-
-
-[dependencies.semver]
-version = ">0.1"
-optional = true
+semver = { version = "1", optional = true }
 
 [dev-dependencies]
 proptest = "1.9.0"
@@ -40,6 +36,7 @@ smallvec = ["dep:smallvec"]
 macro = ["dep:wslplugins-macro", "sys", "dep:tracing"]
 tracing = ["dep:tracing"]
 uuid = ["dep:uuid"]
+semver = ["dep:semver"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { version = "0.1.43", optional = true }
 thiserror = "2.0.7"
 typed-path = ">0.1"
 widestring = { version = "1", features = ["alloc"] }
-wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.2" }
+wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.3" }
 wslpluginapi-sys.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -15,6 +15,7 @@ windows-core = { workspace = true }
 bitflags = { version = ">0.1.0", optional = true }
 enumflags2 = { version = ">0.5", optional = true }
 flagset = { version = ">0.1.0", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 tracing = { version = "0.1.43", optional = true }
 thiserror = "2.0.7"
 typed-path = ">0.1"
@@ -28,11 +29,13 @@ semver = { version = "1", optional = true }
 [dev-dependencies]
 proptest = "1.9.0"
 criterion = "0.8"
+serde_test = "1"
 
 [features]
 default = ["smallvec"]
 sys = []
 smallvec = ["dep:smallvec"]
+serde = ["dep:serde"]
 macro = ["dep:wslplugins-macro", "sys", "dep:tracing"]
 tracing = ["dep:tracing"]
 uuid = ["dep:uuid"]

--- a/crates/wslplugins-rs/src/api/api_v1.rs
+++ b/crates/wslplugins-rs/src/api/api_v1.rs
@@ -3,7 +3,7 @@ use super::Error;
 use super::{Result, WSLCommand};
 use crate::api::errors::require_update_error::Result as UpReqResult;
 use crate::api::wsl_command::IntoCowUtf8UnixPath;
-use crate::{SessionID, UserDistributionID, WSLVersion};
+use crate::{HasSessionId, SessionID, UserDistributionID, WSLVersion};
 use std::ffi::OsStr;
 use std::fmt::{self, Debug};
 use std::mem::MaybeUninit;
@@ -102,18 +102,19 @@ impl ApiV1 {
     pub fn mount_folder<
         WP: AsRef<Path> + std::fmt::Debug,
         UP: AsRef<Utf8UnixPath> + std::fmt::Debug,
+        S: AsRef<OsStr> + std::fmt::Debug,
     >(
         &self,
         session_id: SessionID,
         windows_path: WP,
         linux_path: UP,
         read_only: bool,
-        name: &OsStr,
+        name: S,
     ) -> WinResult<()> {
         let encoded_windows_path =
             U16CString::from_os_str_truncate(windows_path.as_ref().as_os_str());
         let encoded_linux_path = U16CString::from_str_truncate(linux_path.as_ref().as_str());
-        let encoded_name = U16CString::from_os_str_truncate(name);
+        let encoded_name = U16CString::from_os_str_truncate(name.as_ref());
         // SAFETY:
         // - `self.0.MountFolder` comes from the validated `WSLPluginAPIV1` struct provided by WSL.
         //   The API guarantees that this function pointer is non-null for supported versions.
@@ -219,9 +220,9 @@ impl ApiV1 {
     /// - The default execution target is [`DistributionID::System`].
     /// - `argv[0]` defaults to the program path unless explicitly overridden.
     #[inline]
-    pub fn new_command<'a, P: IntoCowUtf8UnixPath<'a>>(
+    pub fn new_command<'a, S: HasSessionId, P: IntoCowUtf8UnixPath<'a>>(
         &'a self,
-        session_id: SessionID,
+        session_id: S,
         program: P,
     ) -> WSLCommand<'a> {
         WSLCommand::new(self, session_id, program)

--- a/crates/wslplugins-rs/src/api/api_v1.rs
+++ b/crates/wslplugins-rs/src/api/api_v1.rs
@@ -73,7 +73,9 @@ impl ApiV1 {
     /// let version = api_v1.version();
     /// println!(
     ///     "WSL API version: {}.{}.{}",
-    ///     version.Major, version.Minor, version.Revision
+    ///     version.major(),
+    ///     version.minor(),
+    ///     version.revision(),
     /// );
     #[must_use]
     #[inline]

--- a/crates/wslplugins-rs/src/api/errors.rs
+++ b/crates/wslplugins-rs/src/api/errors.rs
@@ -15,7 +15,7 @@ use wslpluginapi_sys::WSL_E_PLUGIN_REQUIRES_UPDATE;
 /// This enum encapsulates two main error categories:
 /// - Plugin-specific errors (`RequireUpdateError`).
 /// - Errors originating from Windows APIs (`WinError`).
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 pub enum Error {
     /// Indicates that the current WSL version does not meet the required version.
     #[error("Require Update Error")]

--- a/crates/wslplugins-rs/src/api/errors/require_update_error.rs
+++ b/crates/wslplugins-rs/src/api/errors/require_update_error.rs
@@ -16,7 +16,7 @@ use windows_core::HRESULT;
 /// # Fields
 /// - `current_version`: The current WSL version.
 /// - `required_version`: The required WSL version.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
 #[error("WSLVersion unsupported: current version {current_version}, required version {required_version}")]
 pub struct Error {
     /// The current version of WSL.

--- a/crates/wslplugins-rs/src/api/utils.rs
+++ b/crates/wslplugins-rs/src/api/utils.rs
@@ -19,8 +19,8 @@ pub(crate) fn check_required_version_result(
         Ok(())
     } else {
         Err(Error {
-            current_version: current_version.clone(),
-            required_version: required_version.clone(),
+            current_version: *current_version,
+            required_version: *required_version,
         })
     }
 }

--- a/crates/wslplugins-rs/src/api/wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command.rs
@@ -14,7 +14,7 @@ pub use wsl_command_execution::WSLCommandExecution;
 use smallvec::SmallVec;
 
 #[cfg(doc)]
-use crate::{api::Error as ApiError, CoreDistributionInformation, UserDistributionID};
+use crate::{api::Error as ApiError, CoreWSLDistributionInformation, UserDistributionID};
 mod prepared_wsl_command;
 #[cfg(not(feature = "smallvec"))]
 type ArgVec<'a> = Vec<Cow<'a, str>>;
@@ -277,7 +277,7 @@ impl<'a> WSLCommand<'a> {
     /// - a [`DistributionID`] directly,
     /// - a [`UserDistributionID`],
     /// - an [`Option<UserDistributionID>`],
-    /// - a reference to a type implementing [`CoreDistributionInformation`].
+    /// - a reference to a type implementing [`CoreWSLDistributionInformation`].
     #[inline]
     #[must_use]
     #[allow(clippy::missing_const_for_fn, reason = "Useless const")]
@@ -292,7 +292,7 @@ impl<'a> WSLCommand<'a> {
     /// - a [`DistributionID`] directly,
     /// - a [`UserDistributionID`],
     /// - an [`Option<UserDistributionID>`],
-    /// - a reference to a type implementing [`CoreDistributionInformation`].
+    /// - a reference to a type implementing [`CoreWSLDistributionInformation`].
     #[inline]
     #[must_use]
     #[allow(clippy::missing_const_for_fn, reason = "Useless const")]

--- a/crates/wslplugins-rs/src/api/wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command.rs
@@ -1,5 +1,5 @@
 use super::super::api::{ApiV1, Result as ApiResult};
-use crate::{DistributionID, SessionID};
+use crate::{DistributionID, HasSessionId, SessionID};
 use core::clone::Clone;
 use std::{borrow::Cow, iter::once, net::TcpStream};
 use typed_path::Utf8UnixPath;
@@ -14,7 +14,7 @@ pub use wsl_command_execution::WSLCommandExecution;
 use smallvec::SmallVec;
 
 #[cfg(doc)]
-use super::super::api::Error as ApiError;
+use crate::{api::Error as ApiError, CoreDistributionInformation, UserDistributionID};
 mod prepared_wsl_command;
 #[cfg(not(feature = "smallvec"))]
 type ArgVec<'a> = Vec<Cow<'a, str>>;
@@ -146,9 +146,9 @@ impl<'a> WSLCommand<'a> {
     /// - The default target is [`DistributionID::System`].
     /// - `argv[0]` is the program path string unless overridden via [`WSLCommand::arg0`]
     ///   or [`WSLCommand::with_arg0`].
-    pub(crate) fn new<P: IntoCowUtf8UnixPath<'a>>(
+    pub(crate) fn new<P: IntoCowUtf8UnixPath<'a>, S: HasSessionId>(
         api: &'a ApiV1,
-        session_id: SessionID,
+        session_id: S,
         program: P,
     ) -> Self {
         Self {
@@ -157,7 +157,7 @@ impl<'a> WSLCommand<'a> {
             args: ArgVec::new(),
             path: program.into_cow_utf8_unix_path(),
             distribution_id: DistributionID::System,
-            session_id,
+            session_id: session_id.session_id(),
         }
     }
 
@@ -272,20 +272,32 @@ impl<'a> WSLCommand<'a> {
     }
 
     /// Sets the distribution target (builder-style by mutable reference).
+    ///
+    /// This accepts any value convertible into a [`DistributionID`], including:
+    /// - a [`DistributionID`] directly,
+    /// - a [`UserDistributionID`],
+    /// - an [`Option<UserDistributionID>`],
+    /// - a reference to a type implementing [`CoreDistributionInformation`].
     #[inline]
     #[must_use]
     #[allow(clippy::missing_const_for_fn, reason = "Useless const")]
-    pub fn distribution_id(&mut self, distribution_id: DistributionID) -> &mut Self {
-        self.distribution_id = distribution_id;
+    pub fn distribution_id<T: Into<DistributionID>>(&mut self, distribution_id: T) -> &mut Self {
+        self.distribution_id = distribution_id.into();
         self
     }
 
     /// Sets the distribution target (builder-style by value).
+    ///
+    /// This accepts any value convertible into a [`DistributionID`], including:
+    /// - a [`DistributionID`] directly,
+    /// - a [`UserDistributionID`],
+    /// - an [`Option<UserDistributionID>`],
+    /// - a reference to a type implementing [`CoreDistributionInformation`].
     #[inline]
     #[must_use]
     #[allow(clippy::missing_const_for_fn, reason = "Useless const")]
-    pub fn with_distribution_id(mut self, distribution_id: DistributionID) -> Self {
-        self.distribution_id = distribution_id;
+    pub fn with_distribution_id<T: Into<DistributionID>>(mut self, distribution_id: T) -> Self {
+        self.distribution_id = distribution_id.into();
         self
     }
 

--- a/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
@@ -5,7 +5,7 @@
 //! and package family name, offering a consistent interface for interacting with WSL distributions.
 //!
 //! ## Overview
-//! The `CoreDistributionInformation` trait is designed to abstract the key properties
+//! The `CoreWSLDistributionInformation` trait is designed to abstract the key properties
 //! of a distribution. Implementing this trait allows for seamless integration with systems
 //! that need to handle multiple distributions in a consistent manner.
 
@@ -16,7 +16,7 @@ use std::ffi::OsString;
 ///
 /// This trait abstracts the common properties of a WSL distribution, such as its unique ID,
 /// display name, and package family name (if applicable).
-pub trait CoreDistributionInformation {
+pub trait CoreWSLDistributionInformation {
     /// Retrieves the unique ID of the distribution.
     ///
     /// The ID is guaranteed to remain the same across reboots.

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -41,28 +41,27 @@ use thiserror::Error;
 ///   user distributions for operations like Linux GUI apps.
 /// - User distributions provide isolated environments for specific Linux distributions, allowing
 ///   users to install and run various Linux distributions on their Windows machines.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum DistributionID {
     /// Represents the system-level distribution.
     /// For more info about the system distribution please check the [WSLg architecture blogpost](https://devblogs.microsoft.com/commandline/wslg-architecture/#system-distro)
+    #[default]
     System,
     /// Represents an installed user-specific distribution identified by a [`UserDistributionID`].
     User(UserDistributionID),
 }
 
-impl Default for DistributionID {
-    fn default() -> Self {
-        Self::System
-    }
-}
-
 impl DistributionID {
     /// Checks if the distribution is a distribution installed by the user.
-    pub fn is_user(&self) -> bool {
+    #[must_use]
+    #[inline]
+    pub const fn is_user(&self) -> bool {
         matches!(*self, Self::User(_))
     }
     /// Checks if the distribution is the system distribution.
-    pub fn is_system(&self) -> bool {
+    #[must_use]
+    #[inline]
+    pub const fn is_system(&self) -> bool {
         matches!(*self, Self::System)
     }
 }

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -41,11 +41,10 @@ use thiserror::Error;
 ///   user distributions for operations like Linux GUI apps.
 /// - User distributions provide isolated environments for specific Linux distributions, allowing
 ///   users to install and run various Linux distributions on their Windows machines.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DistributionID {
     /// Represents the system-level distribution.
     /// For more info about the system distribution please check the [WSLg architecture blogpost](https://devblogs.microsoft.com/commandline/wslg-architecture/#system-distro)
-    #[default]
     System,
     /// Represents an installed user-specific distribution identified by a [`UserDistributionID`].
     User(UserDistributionID),
@@ -168,11 +167,6 @@ mod tests {
         fn version(&self) -> Result<Option<OsString>> {
             Ok(None)
         }
-    }
-
-    #[test]
-    fn default_returns_system() {
-        assert_eq!(DistributionID::default(), DistributionID::System);
     }
 
     #[test]

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -41,7 +41,7 @@ use thiserror::Error;
 ///   user distributions for operations like Linux GUI apps.
 /// - User distributions provide isolated environments for specific Linux distributions, allowing
 ///   users to install and run various Linux distributions on their Windows machines.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DistributionID {
     /// Represents the system-level distribution.
     /// For more info about the system distribution please check the [WSLg architecture blogpost](https://devblogs.microsoft.com/commandline/wslg-architecture/#system-distro)
@@ -50,8 +50,25 @@ pub enum DistributionID {
     User(UserDistributionID),
 }
 
+impl Default for DistributionID {
+    fn default() -> Self {
+        Self::System
+    }
+}
+
+impl DistributionID {
+    /// Checks if the distribution is a distribution installed by the user.
+    pub fn is_user(&self) -> bool {
+        matches!(*self, Self::User(_))
+    }
+    /// Checks if the distribution is the system distribution.
+    pub fn is_system(&self) -> bool {
+        matches!(*self, Self::System)
+    }
+}
+
 /// Error type for conversion failures between [`DistributionID`] and [`UserDistributionID`].
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
 #[error("Cannot convert System distribution to UserDistribution.")]
 pub struct ConversionError;
 
@@ -116,6 +133,159 @@ impl Display for DistributionID {
         match self {
             Self::System => f.write_str("System"),
             Self::User(id) => std::fmt::Display::fmt(id, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::errors::require_update_error::Result;
+    use proptest::prelude::*;
+    use std::ffi::OsString;
+
+    #[derive(Clone, Copy)]
+    struct TestDistribution {
+        id: UserDistributionID,
+    }
+
+    impl CoreDistributionInformation for TestDistribution {
+        fn id(&self) -> UserDistributionID {
+            self.id
+        }
+
+        fn name(&self) -> OsString {
+            OsString::from("test")
+        }
+
+        fn package_family_name(&self) -> Option<OsString> {
+            None
+        }
+
+        fn flavor(&self) -> Result<Option<OsString>> {
+            Ok(None)
+        }
+
+        fn version(&self) -> Result<Option<OsString>> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn default_returns_system() {
+        assert_eq!(DistributionID::default(), DistributionID::System);
+    }
+
+    #[test]
+    fn is_system_returns_true_for_system_distribution() {
+        assert!(DistributionID::System.is_system());
+    }
+
+    #[test]
+    fn is_user_returns_false_for_system_distribution() {
+        assert!(!DistributionID::System.is_user());
+    }
+
+    #[test]
+    fn try_from_system_returns_error() {
+        assert_eq!(
+            UserDistributionID::try_from(DistributionID::System),
+            Err(ConversionError)
+        );
+    }
+
+    #[test]
+    fn from_none_returns_system() {
+        assert_eq!(
+            DistributionID::from(Option::<UserDistributionID>::None),
+            DistributionID::System
+        );
+    }
+
+    #[test]
+    fn option_from_system_returns_none() {
+        let maybe_user: Option<UserDistributionID> = DistributionID::System.into();
+        assert_eq!(maybe_user, None);
+    }
+
+    #[test]
+    fn display_for_system_is_system() {
+        assert_eq!(format!("{}", DistributionID::System), "System");
+    }
+
+    proptest! {
+        #[test]
+        fn is_system_returns_false_for_user_distribution(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+
+            prop_assert!(!DistributionID::User(user_id).is_system());
+        }
+
+        #[test]
+        fn is_user_returns_true_for_user_distribution(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+
+            prop_assert!(DistributionID::User(user_id).is_user());
+        }
+
+        #[test]
+        fn try_from_user_returns_inner_id(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+
+            prop_assert_eq!(
+                UserDistributionID::try_from(DistributionID::User(user_id)),
+                Ok(user_id)
+            );
+        }
+
+        #[test]
+        fn from_user_distribution_id_wraps_user_variant(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+
+            prop_assert_eq!(DistributionID::from(user_id), DistributionID::User(user_id));
+        }
+
+        #[test]
+        fn from_user_distribution_id_reference_wraps_user_variant(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+
+            prop_assert_eq!(DistributionID::from(&user_id), DistributionID::User(user_id));
+        }
+
+        #[test]
+        fn from_some_user_distribution_id_wraps_user_variant(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+
+            prop_assert_eq!(
+                DistributionID::from(Some(user_id)),
+                DistributionID::User(user_id)
+            );
+        }
+
+        #[test]
+        fn option_from_user_distribution_returns_some_inner_id(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+            let maybe_user: Option<UserDistributionID> = DistributionID::User(user_id).into();
+
+            prop_assert_eq!(maybe_user, Some(user_id));
+        }
+
+        #[test]
+        fn display_for_user_delegates_to_user_distribution_id(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+
+            prop_assert_eq!(
+                format!("{}", DistributionID::User(user_id)),
+                format!("{user_id}")
+            );
+        }
+
+        #[test]
+        fn from_core_distribution_information_uses_the_underlying_id(raw_id in any::<u128>()) {
+            let user_id = UserDistributionID::from(windows_core::GUID::from_u128(raw_id));
+            let distribution = TestDistribution { id: user_id };
+
+            prop_assert_eq!(DistributionID::from(&distribution), DistributionID::User(user_id));
         }
     }
 }

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -10,12 +10,12 @@
 //!   into a [`DistributionID`],
 //! - converting a [`DistributionID`] back into `Option<UserDistributionID>`,
 //! - retrieving a distribution identifier from any
-//!   [`CoreDistributionInformation`] implementation.
+//!   [`CoreWSLDistributionInformation`] implementation.
 //!
 //! When a caller needs a user distribution identifier and receives
 //! [`DistributionID::System`] instead, [`UserDistributionIDConversionError`] is returned.
 
-use crate::{CoreDistributionInformation, UserDistributionID};
+use crate::{CoreWSLDistributionInformation, UserDistributionID};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -42,7 +42,6 @@ pub use crate::user_distribution_id::UserDistributionIDConversionError;
 ///   user distributions for operations like Linux GUI apps.
 /// - User distributions provide isolated environments for specific Linux distributions, allowing
 ///   users to install and run various Linux distributions on their Windows machines.
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DistributionID {
@@ -82,8 +81,8 @@ impl From<&UserDistributionID> for DistributionID {
     }
 }
 
-impl<T: CoreDistributionInformation> From<&T> for DistributionID {
-    /// Converts a reference to a type implementing `CoreDistributionInformation` into a `DistributionID`.
+impl<T: CoreWSLDistributionInformation> From<&T> for DistributionID {
+    /// Converts a reference to a type implementing `CoreWSLDistributionInformation` into a `DistributionID`.
     #[inline]
     fn from(value: &T) -> Self {
         value.id().into()
@@ -134,7 +133,7 @@ mod tests {
         id: UserDistributionID,
     }
 
-    impl CoreDistributionInformation for TestDistribution {
+    impl CoreWSLDistributionInformation for TestDistribution {
         fn id(&self) -> UserDistributionID {
             self.id
         }

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -1,25 +1,24 @@
-//! # Module `DistributionID`
+//! Distribution identifiers used by the crate.
 //!
-//! This module defines an abstraction to represent WSL distributions through a
-//! [`DistributionID`]. It supports two types of identifiers: system-level distributions
-//! and user-specific installed distributions identified by a GUID.
+//! [`DistributionID`] models the two kinds of distributions exposed by WSL:
+//! the shared system distribution and user-installed distributions identified by
+//! a [`UserDistributionID`].
 //!
-//! ## Key Features
+//! The module also exposes the conversions commonly needed by the API surface:
 //!
-//! - Bi-directional conversion between [`DistributionID`] and [`UserDistributionID`].
-//! - Robust error handling for conversions via [`ConversionError`].
-//! - Display implementation ([Display]) and support for other idiomatic conversions.
+//! - converting from a [`UserDistributionID`] or `Option<UserDistributionID>`
+//!   into a [`DistributionID`],
+//! - converting a [`DistributionID`] back into `Option<UserDistributionID>`,
+//! - retrieving a distribution identifier from any
+//!   [`CoreDistributionInformation`] implementation.
 //!
-//! ## Usage Context
-//!
-//! This abstraction is particularly useful in environments where WSL requires
-//! distribution identification via GUIDs or when a distinction between a system-level
-//! distribution and a user-specific distribution is necessary. The associated functions
-//! and conversions simplify integration with APIs like those defined in `WslPluginApi`.
+//! When a caller needs a user distribution identifier and receives
+//! [`DistributionID::System`] instead, [`UserDistributionIDConversionError`] is returned.
 
 use crate::{CoreDistributionInformation, UserDistributionID};
-use std::{convert::TryFrom, fmt::Display};
-use thiserror::Error;
+use std::fmt::Display;
+
+pub use crate::user_distribution_id::UserDistributionIDConversionError;
 
 /// Represents a distribution identifier in the Windows Subsystem for Linux (WSL).
 ///
@@ -62,22 +61,6 @@ impl DistributionID {
     #[inline]
     pub const fn is_system(&self) -> bool {
         matches!(*self, Self::System)
-    }
-}
-
-/// Error type for conversion failures between [`DistributionID`] and [`UserDistributionID`].
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
-#[error("Cannot convert System distribution to UserDistribution.")]
-pub struct ConversionError;
-
-impl TryFrom<DistributionID> for UserDistributionID {
-    type Error = ConversionError;
-    #[inline]
-    fn try_from(value: DistributionID) -> Result<Self, Self::Error> {
-        match value {
-            DistributionID::User(id) => Ok(id),
-            DistributionID::System => Err(ConversionError),
-        }
     }
 }
 
@@ -177,14 +160,6 @@ mod tests {
     #[test]
     fn is_user_returns_false_for_system_distribution() {
         assert!(!DistributionID::System.is_user());
-    }
-
-    #[test]
-    fn try_from_system_returns_error() {
-        assert_eq!(
-            UserDistributionID::try_from(DistributionID::System),
-            Err(ConversionError)
-        );
     }
 
     #[test]

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -16,6 +16,8 @@
 //! [`DistributionID::System`] instead, [`UserDistributionIDConversionError`] is returned.
 
 use crate::{CoreDistributionInformation, UserDistributionID};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
 pub use crate::user_distribution_id::UserDistributionIDConversionError;
@@ -40,7 +42,9 @@ pub use crate::user_distribution_id::UserDistributionIDConversionError;
 ///   user distributions for operations like Linux GUI apps.
 /// - User distributions provide isolated environments for specific Linux distributions, allowing
 ///   users to install and run various Linux distributions on their Windows machines.
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DistributionID {
     /// Represents the system-level distribution.
     /// For more info about the system distribution please check the [WSLg architecture blogpost](https://devblogs.microsoft.com/commandline/wslg-architecture/#system-distro)

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -73,10 +73,17 @@ impl From<UserDistributionID> for DistributionID {
     }
 }
 
-impl<T: CoreDistributionInformation> From<T> for DistributionID {
-    /// Converts a type implementing `CoreDistributionInformation` into a `DistributionID`.
+impl From<&UserDistributionID> for DistributionID {
     #[inline]
-    fn from(value: T) -> Self {
+    fn from(value: &UserDistributionID) -> Self {
+        Self::User(*value)
+    }
+}
+
+impl<T: CoreDistributionInformation> From<&T> for DistributionID {
+    /// Converts a reference to a type implementing `CoreDistributionInformation` into a `DistributionID`.
+    #[inline]
+    fn from(value: &T) -> Self {
         value.id().into()
     }
 }

--- a/crates/wslplugins-rs/src/distribution_information.rs
+++ b/crates/wslplugins-rs/src/distribution_information.rs
@@ -18,6 +18,7 @@ use crate::api::{
     errors::require_update_error::Result, utils::check_required_version_result_from_context,
 };
 use crate::core_distribution_information::CoreDistributionInformation;
+use crate::utils::opt_wide_str;
 use crate::WSLVersion;
 use crate::{UserDistributionID, WSLContext};
 use std::ffi::OsString;
@@ -108,15 +109,7 @@ impl CoreDistributionInformation for DistributionInformation {
 
     #[inline]
     fn package_family_name(&self) -> Option<OsString> {
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = self.0.PackageFamilyName;
-            if ptr.is_null() {
-                None
-            } else {
-                Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide()))
-            }
-        }
+        opt_wide_str(self.0.PackageFamilyName)
     }
 
     #[inline]
@@ -125,15 +118,7 @@ impl CoreDistributionInformation for DistributionInformation {
             WSLContext::get_current(),
             &WSLVersion::new(2, 4, 4),
         )?;
-        // SAFETY: check already inside and before by versionning
-        unsafe {
-            let ptr = self.0.Flavor;
-            if ptr.is_null() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Flavor))
     }
 
     #[inline]
@@ -142,15 +127,7 @@ impl CoreDistributionInformation for DistributionInformation {
             WSLContext::get_current(),
             &WSLVersion::new(2, 4, 4),
         )?;
-        // SAFETY: check did before by versionning.
-        unsafe {
-            let ptr = self.0.Version;
-            if ptr.is_null() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(PCWSTR::from_raw(ptr).as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Version))
     }
 }
 

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -83,5 +83,5 @@ pub use wslplugins_macro::wsl_plugin_v1;
 #[cfg(feature = "sys")]
 pub use wslpluginapi_sys as sys;
 
-pub use session_id::SessionID;
+pub use session_id::{HasSessionId, SessionID};
 pub use user_distribution_id::UserDistributionID;

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -74,7 +74,7 @@ mod wsl_version;
 pub use api::WSLCommandExecution;
 #[cfg(feature = "semver")]
 pub use wsl_version::SemverConversionError;
-pub use wsl_version::WSLVersion;
+pub use wsl_version::{WSLVersion, WSLVersionParseError};
 
 /// Re-exports procedural macros when the `macro` feature is enabled.
 /// It allow to mark a plugin struct (that implement [`WSLPluginV1`] trait) to be easely integrated to the WSL plugin system without writing manually C code for entry point or hooks.

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -37,19 +37,19 @@
 pub mod api;
 
 // Internal modules for managing specific WSL features.
-mod core_distribution_information;
+mod core_wsl_distribution_information;
 pub(crate) mod cstring_ext;
 mod session_id;
 pub mod user_distribution_id;
+mod wsl_offline_distribution_information;
 pub use windows_core;
 #[doc(hidden)]
 #[cfg(feature = "macro")]
 pub mod __private;
 pub mod distribution_id;
-mod distribution_information;
-mod offline_distribution_information;
 mod utils;
 mod wsl_context;
+mod wsl_distribution_information;
 mod wsl_session_information;
 mod wsl_vm_creation_settings;
 #[cfg(doc)]
@@ -63,11 +63,11 @@ pub mod plugin;
 pub mod prelude;
 
 // Re-exports for core structures to simplify usage.
-pub use core_distribution_information::CoreDistributionInformation;
+pub use core_wsl_distribution_information::CoreWSLDistributionInformation;
 pub use distribution_id::DistributionID;
-pub use distribution_information::DistributionInformation;
-pub use offline_distribution_information::OfflineDistributionInformation;
 pub use wsl_context::WSLContext;
+pub use wsl_distribution_information::WSLDistributionInformation;
+pub use wsl_offline_distribution_information::WSLOfflineDistributionInformation;
 pub use wsl_session_information::WSLSessionInformation;
 pub use wsl_vm_creation_settings::WSLVmCreationSettings;
 mod wsl_version;

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -72,6 +72,8 @@ pub use wsl_session_information::WSLSessionInformation;
 pub use wsl_vm_creation_settings::WSLVmCreationSettings;
 mod wsl_version;
 pub use api::WSLCommandExecution;
+#[cfg(feature = "semver")]
+pub use wsl_version::SemverConversionError;
 pub use wsl_version::WSLVersion;
 
 /// Re-exports procedural macros when the `macro` feature is enabled.

--- a/crates/wslplugins-rs/src/offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/offline_distribution_information.rs
@@ -8,6 +8,7 @@ use crate::{
         errors::require_update_error::Result, utils::check_required_version_result_from_context,
     },
     core_distribution_information::CoreDistributionInformation,
+    utils::opt_wide_str,
     UserDistributionID, WSLContext, WSLVersion,
 };
 use std::{
@@ -75,15 +76,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
     /// - `None`: If the package family name is null or empty.
     #[inline]
     fn package_family_name(&self) -> Option<OsString> {
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = PCWSTR::from_raw(self.0.PackageFamilyName);
-            if ptr.is_null() || ptr.is_empty() {
-                None
-            } else {
-                Some(OsString::from_wide(ptr.as_wide()))
-            }
-        }
+        opt_wide_str(self.0.PackageFamilyName)
     }
 
     #[inline]
@@ -93,15 +86,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
             &WSLVersion::new(2, 4, 4),
         )?;
 
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = PCWSTR::from_raw(self.0.Flavor);
-            if ptr.is_null() || ptr.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(ptr.as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Flavor))
     }
 
     #[inline]
@@ -110,15 +95,7 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
             WSLContext::get_current(),
             &WSLVersion::new(2, 4, 4),
         )?;
-        // SAFETY: check already inside
-        unsafe {
-            let ptr = PCWSTR::from_raw(self.0.Version);
-            if ptr.is_null() || ptr.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(OsString::from_wide(ptr.as_wide())))
-            }
-        }
+        Ok(opt_wide_str(self.0.Version))
     }
 }
 

--- a/crates/wslplugins-rs/src/plugin/error.rs
+++ b/crates/wslplugins-rs/src/plugin/error.rs
@@ -62,7 +62,7 @@ impl Error {
     /// A new instance of `Error`.
     #[must_use]
     #[inline]
-    pub fn new(code: HRESULT, message: Option<&OsStr>) -> Self {
+    pub fn new<S: AsRef<OsStr>>(code: HRESULT, message: Option<S>) -> Self {
         let code = if code.is_ok() {
             WinError::from_hresult(code).code()
         } else {
@@ -73,7 +73,7 @@ impl Error {
 
         Self {
             code,
-            message: message.map(ToOwned::to_owned),
+            message: message.map(|m| m.as_ref().to_owned()),
         }
     }
 
@@ -87,7 +87,7 @@ impl Error {
     #[must_use]
     #[inline]
     pub fn with_code(code: HRESULT) -> Self {
-        Self::new(code, None)
+        Self::new::<&OsStr>(code, None)
     }
 
     /// Creates an error with both a code and a message.
@@ -100,7 +100,7 @@ impl Error {
     /// A new instance of `Error`.
     #[must_use]
     #[inline]
-    pub fn with_message(code: HRESULT, message: &OsStr) -> Self {
+    pub fn with_message<S: AsRef<OsStr>>(code: HRESULT, message: S) -> Self {
         Self::new(code, Some(message))
     }
 
@@ -195,7 +195,7 @@ impl From<HRESULT> for Error {
     /// An `Error` containing the `HRESULT` as its code.
     #[inline]
     fn from(value: HRESULT) -> Self {
-        Self::new(value, None)
+        Self::new::<&OsStr>(value, None)
     }
 }
 

--- a/crates/wslplugins-rs/src/plugin/error.rs
+++ b/crates/wslplugins-rs/src/plugin/error.rs
@@ -24,7 +24,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// This struct encapsulates:
 /// - An error code (`HRESULT`) derived from Windows APIs.
 /// - An optional error message (`OsString`).
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 pub struct Error {
     /// The error code associated with the failure.
     code: NonZeroI32,

--- a/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
+++ b/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
@@ -8,8 +8,8 @@
 use super::error::Error;
 use super::error::Result;
 use crate::{
-    distribution_information::DistributionInformation,
-    offline_distribution_information::OfflineDistributionInformation,
+    wsl_distribution_information::WSLDistributionInformation,
+    wsl_offline_distribution_information::WSLOfflineDistributionInformation,
     wsl_session_information::WSLSessionInformation,
     wsl_vm_creation_settings::WSLVmCreationSettings, WSLContext,
 };
@@ -112,7 +112,7 @@ pub trait WSLPluginV1: Sized + Sync {
     fn on_distribution_started(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> Result<()> {
         Ok(())
     }
@@ -136,7 +136,7 @@ pub trait WSLPluginV1: Sized + Sync {
     fn on_distribution_stopping(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> WinResult<()> {
         Ok(())
     }
@@ -159,7 +159,7 @@ pub trait WSLPluginV1: Sized + Sync {
     fn on_distribution_registered(
         &self,
         session: &WSLSessionInformation,
-        distribution: &OfflineDistributionInformation,
+        distribution: &WSLOfflineDistributionInformation,
     ) -> WinResult<()> {
         Ok(())
     }
@@ -184,7 +184,7 @@ pub trait WSLPluginV1: Sized + Sync {
     fn on_distribution_unregistered(
         &self,
         session: &WSLSessionInformation,
-        distribution: &OfflineDistributionInformation,
+        distribution: &WSLOfflineDistributionInformation,
     ) -> WinResult<()> {
         Ok(())
     }

--- a/crates/wslplugins-rs/src/prelude.rs
+++ b/crates/wslplugins-rs/src/prelude.rs
@@ -21,8 +21,8 @@ pub use crate::windows_core::{Error as WinError, Result as WinResult};
 pub use crate::SemverConversionError;
 pub use crate::WSLVersionParseError;
 pub use crate::{
-    CoreDistributionInformation, DistributionID, DistributionInformation, HasSessionId,
-    OfflineDistributionInformation, SessionID, UserDistributionID, WSLContext,
+    CoreWSLDistributionInformation, DistributionID, HasSessionId, SessionID, UserDistributionID,
+    WSLContext, WSLDistributionInformation, WSLOfflineDistributionInformation,
     WSLSessionInformation, WSLUserConfiguration, WSLVersion, WSLVmCreationSettings,
 };
 

--- a/crates/wslplugins-rs/src/prelude.rs
+++ b/crates/wslplugins-rs/src/prelude.rs
@@ -18,7 +18,7 @@ pub use crate::api::{Error as ApiError, Result as ApiResult};
 pub use crate::plugin::{Error as PluginError, Result as PluginResult, WSLPluginV1};
 pub use crate::windows_core::{Error as WinError, Result as WinResult};
 pub use crate::{
-    CoreDistributionInformation, DistributionID, DistributionInformation,
+    CoreDistributionInformation, DistributionID, DistributionInformation, HasSessionId,
     OfflineDistributionInformation, SessionID, UserDistributionID, WSLContext,
     WSLSessionInformation, WSLUserConfiguration, WSLVersion, WSLVmCreationSettings,
 };

--- a/crates/wslplugins-rs/src/prelude.rs
+++ b/crates/wslplugins-rs/src/prelude.rs
@@ -17,6 +17,8 @@ pub use crate::api::{ApiV1, PreparedWSLCommand, WSLCommand, WSLCommandExecution}
 pub use crate::api::{Error as ApiError, Result as ApiResult};
 pub use crate::plugin::{Error as PluginError, Result as PluginResult, WSLPluginV1};
 pub use crate::windows_core::{Error as WinError, Result as WinResult};
+#[cfg(feature = "semver")]
+pub use crate::SemverConversionError;
 pub use crate::{
     CoreDistributionInformation, DistributionID, DistributionInformation, HasSessionId,
     OfflineDistributionInformation, SessionID, UserDistributionID, WSLContext,

--- a/crates/wslplugins-rs/src/prelude.rs
+++ b/crates/wslplugins-rs/src/prelude.rs
@@ -19,6 +19,7 @@ pub use crate::plugin::{Error as PluginError, Result as PluginResult, WSLPluginV
 pub use crate::windows_core::{Error as WinError, Result as WinResult};
 #[cfg(feature = "semver")]
 pub use crate::SemverConversionError;
+pub use crate::WSLVersionParseError;
 pub use crate::{
     CoreDistributionInformation, DistributionID, DistributionInformation, HasSessionId,
     OfflineDistributionInformation, SessionID, UserDistributionID, WSLContext,

--- a/crates/wslplugins-rs/src/session_id.rs
+++ b/crates/wslplugins-rs/src/session_id.rs
@@ -1,7 +1,19 @@
+use crate::WSLSessionInformation;
 use std::fmt::{self, Debug, Display};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SessionID(pub u32);
+
+pub trait HasSessionId {
+    fn session_id(&self) -> SessionID;
+}
+
+impl<T: HasSessionId + ?Sized> HasSessionId for &T {
+    #[inline]
+    fn session_id(&self) -> SessionID {
+        (*self).session_id()
+    }
+}
 
 impl From<u32> for SessionID {
     #[inline]
@@ -14,6 +26,20 @@ impl From<SessionID> for u32 {
     #[inline]
     fn from(value: SessionID) -> Self {
         value.0
+    }
+}
+
+impl From<&WSLSessionInformation> for SessionID {
+    #[inline]
+    fn from(value: &WSLSessionInformation) -> Self {
+        value.id()
+    }
+}
+
+impl HasSessionId for SessionID {
+    #[inline]
+    fn session_id(&self) -> SessionID {
+        *self
     }
 }
 

--- a/crates/wslplugins-rs/src/session_id.rs
+++ b/crates/wslplugins-rs/src/session_id.rs
@@ -1,6 +1,10 @@
 use crate::WSLSessionInformation;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SessionID(pub u32);
 

--- a/crates/wslplugins-rs/src/user_distribution_id.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id.rs
@@ -36,6 +36,7 @@ impl From<wslpluginapi_sys::windows_sys::core::GUID> for UserDistributionID {
 }
 
 impl<T: CoreDistributionInformation> From<&T> for UserDistributionID {
+    /// Converts a reference to a type implementing `CoreDistributionInformation` into a `UserDistributionID`.
     #[inline]
     fn from(value: &T) -> Self {
         value.id()

--- a/crates/wslplugins-rs/src/user_distribution_id.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id.rs
@@ -12,7 +12,7 @@ use crate::CoreDistributionInformation;
 mod uuid_impl;
 
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct UserDistributionID(pub windows_core::GUID);
 
 impl From<windows_core::GUID> for UserDistributionID {

--- a/crates/wslplugins-rs/src/user_distribution_id.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id.rs
@@ -9,10 +9,17 @@ use fmt::DefaultFormatter;
 pub use parse_error::ParseError;
 
 use crate::{CoreDistributionInformation, DistributionID};
+#[cfg(feature = "serde")]
+mod serde_impl;
 #[cfg(feature = "uuid")]
 mod uuid_impl;
 
 #[repr(transparent)]
+/// Identifier for a user-installed WSL distribution.
+///
+/// When the `serde` feature is enabled, human-readable serializers encode this
+/// type as the canonical GUID string. Non-human-readable serializers encode it
+/// as the native 16-byte Windows GUID memory layout for Windows API interop.
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct UserDistributionID(pub windows_core::GUID);
 

--- a/crates/wslplugins-rs/src/user_distribution_id.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id.rs
@@ -2,18 +2,24 @@ use std::{
     fmt::{Debug, Display, LowerHex, UpperHex},
     str::FromStr,
 };
+use thiserror::Error;
 pub mod fmt;
 mod parse_error;
 use fmt::DefaultFormatter;
 pub use parse_error::ParseError;
 
-use crate::CoreDistributionInformation;
+use crate::{CoreDistributionInformation, DistributionID};
 #[cfg(feature = "uuid")]
 mod uuid_impl;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct UserDistributionID(pub windows_core::GUID);
+
+/// Error type for conversion failures between [`DistributionID`] and [`UserDistributionID`].
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
+#[error("Cannot convert System distribution to UserDistribution.")]
+pub struct UserDistributionIDConversionError;
 
 impl From<windows_core::GUID> for UserDistributionID {
     #[inline]
@@ -40,6 +46,17 @@ impl<T: CoreDistributionInformation> From<&T> for UserDistributionID {
     #[inline]
     fn from(value: &T) -> Self {
         value.id()
+    }
+}
+
+impl TryFrom<DistributionID> for UserDistributionID {
+    type Error = UserDistributionIDConversionError;
+    #[inline]
+    fn try_from(value: DistributionID) -> Result<Self, Self::Error> {
+        match value {
+            DistributionID::User(id) => Ok(id),
+            DistributionID::System => Err(UserDistributionIDConversionError),
+        }
     }
 }
 
@@ -115,5 +132,13 @@ mod tests {
             prop_assert_eq!(format!("{:X}", user_dist_id), format!("{:?}", user_dist_id));
             prop_assert_eq!(format!("{:x}", user_dist_id), format!("{user_dist_id:X}").to_ascii_lowercase());
         }
+    }
+
+    #[test]
+    fn try_from_system_returns_error() {
+        assert_eq!(
+            UserDistributionID::try_from(DistributionID::System),
+            Err(UserDistributionIDConversionError)
+        );
     }
 }

--- a/crates/wslplugins-rs/src/user_distribution_id.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id.rs
@@ -8,7 +8,7 @@ mod parse_error;
 use fmt::DefaultFormatter;
 pub use parse_error::ParseError;
 
-use crate::{CoreDistributionInformation, DistributionID};
+use crate::{CoreWSLDistributionInformation, DistributionID};
 #[cfg(feature = "serde")]
 mod serde_impl;
 #[cfg(feature = "uuid")]
@@ -48,8 +48,8 @@ impl From<wslpluginapi_sys::windows_sys::core::GUID> for UserDistributionID {
     }
 }
 
-impl<T: CoreDistributionInformation> From<&T> for UserDistributionID {
-    /// Converts a reference to a type implementing `CoreDistributionInformation` into a `UserDistributionID`.
+impl<T: CoreWSLDistributionInformation> From<&T> for UserDistributionID {
+    /// Converts a reference to a type implementing `CoreWSLDistributionInformation` into a `UserDistributionID`.
     #[inline]
     fn from(value: &T) -> Self {
         value.id()

--- a/crates/wslplugins-rs/src/user_distribution_id/parse_error.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id/parse_error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 use windows_core::HRESULT;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 pub enum ParseError {
     #[error("Windows error: HRESULT={0}")]
     Windows(HRESULT),

--- a/crates/wslplugins-rs/src/user_distribution_id/serde_impl.rs
+++ b/crates/wslplugins-rs/src/user_distribution_id/serde_impl.rs
@@ -1,0 +1,188 @@
+//! Serde support for [`crate::UserDistributionID`].
+//!
+//! Human-readable serializers use the canonical GUID string representation.
+//! Compact serializers use the native 16-byte Windows GUID memory layout rather
+//! than RFC 4122 byte order so the encoded bytes match Windows API expectations.
+
+use std::{ptr, slice};
+use windows_core::GUID;
+
+use crate::UserDistributionID;
+
+#[inline]
+const fn guid_to_windows_bytes(guid: &windows_core::GUID) -> &[u8] {
+    // SAFETY: The layout of windows_core::GUID is guaranteed to be 16 bytes and match the Windows GUID layout
+    unsafe { slice::from_raw_parts(std::ptr::from_ref::<GUID>(guid).cast::<u8>(), 16) }
+}
+
+#[inline]
+const fn guid_from_windows_bytes(bytes: &[u8; 16]) -> GUID {
+    // SAFETY: We know guid is 16 bytes and the caller guarantees the bytes are a valid Windows [GUID] representation
+    unsafe { ptr::read_unaligned(bytes.as_ptr().cast::<GUID>()) }
+}
+
+impl serde::Serialize for UserDistributionID {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.collect_str(self)
+        } else {
+            serializer.serialize_bytes(guid_to_windows_bytes(&self.0))
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for UserDistributionID {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct UserDistributionIDVisitor;
+
+        impl UserDistributionIDVisitor {
+            fn from_str<E>(value: &str) -> Result<UserDistributionID, E>
+            where
+                E: serde::de::Error,
+            {
+                value.parse::<UserDistributionID>().map_err(E::custom)
+            }
+
+            fn from_bytes<E>(bytes: &[u8]) -> Result<UserDistributionID, E>
+            where
+                E: serde::de::Error,
+            {
+                if bytes.len() != 16 {
+                    return Err(E::invalid_length(bytes.len(), &"a 16-byte GUID"));
+                }
+
+                let bytes: [u8; 16] = bytes
+                    .try_into()
+                    .map_err(|_| E::custom("invalid GUID format in byte array"))?;
+                Ok(UserDistributionID(guid_from_windows_bytes(&bytes)))
+            }
+
+            fn from_seq<'de, A>(mut seq: A) -> Result<UserDistributionID, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut bytes = [0u8; 16];
+                for (index, slot) in bytes.iter_mut().enumerate() {
+                    *slot = seq.next_element()?.ok_or_else(|| {
+                        serde::de::Error::invalid_length(index, &"a 16-byte GUID")
+                    })?;
+                }
+
+                if seq.next_element::<u8>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(17, &"a 16-byte GUID"));
+                }
+
+                Ok(UserDistributionID(guid_from_windows_bytes(&bytes)))
+            }
+        }
+
+        impl<'de> serde::de::Visitor<'de> for UserDistributionIDVisitor {
+            type Value = UserDistributionID;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a GUID string or 16-byte GUID")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Self::from_str(value)
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Self::from_bytes(value)
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                Self::from_seq(seq)
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(UserDistributionIDVisitor)
+        } else {
+            deserializer.deserialize_bytes(UserDistributionIDVisitor)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::UserDistributionID;
+    use serde_test::{assert_tokens, Configure, Token};
+    use std::str::FromStr;
+    use windows_core::GUID;
+
+    #[test]
+    fn serde_roundtrip_uses_guid_string() {
+        let value = UserDistributionID(GUID::from_u128(0x12345678_9abc_def0_1357_2468ace0bdf1));
+        assert_tokens(
+            &value.readable(),
+            &[Token::Str("12345678-9ABC-DEF0-1357-2468ACE0BDF1")],
+        );
+    }
+
+    #[test]
+    fn serde_compact_uses_windows_guid_bytes() {
+        let value = UserDistributionID(GUID::from_u128(0x12345678_9abc_def0_1357_2468ace0bdf1));
+
+        assert_tokens(
+            &value.compact(),
+            &[Token::BorrowedBytes(&[
+                0x78, 0x56, 0x34, 0x12, 0xbc, 0x9a, 0xf0, 0xde, 0x13, 0x57, 0x24, 0x68, 0xac, 0xe0,
+                0xbd, 0xf1,
+            ])],
+        );
+    }
+
+    #[test]
+    fn binary_layout_matches_windows_guid_layout() {
+        let guid = GUID::from_u128(0x12345678_9abc_def0_1357_2468ace0bdf1);
+        assert_eq!(
+            super::guid_to_windows_bytes(&guid),
+            [
+                0x78, 0x56, 0x34, 0x12, 0xbc, 0x9a, 0xf0, 0xde, 0x13, 0x57, 0x24, 0x68, 0xac, 0xe0,
+                0xbd, 0xf1,
+            ]
+        );
+    }
+
+    #[test]
+    fn binary_deserialization_uses_windows_guid_layout() {
+        let bytes = [
+            0x78, 0x56, 0x34, 0x12, 0xbc, 0x9a, 0xf0, 0xde, 0x13, 0x57, 0x24, 0x68, 0xac, 0xe0,
+            0xbd, 0xf1,
+        ];
+        let guid = super::guid_from_windows_bytes(&bytes);
+        assert_eq!(
+            guid,
+            GUID::from_u128(0x12345678_9abc_def0_1357_2468ace0bdf1)
+        );
+    }
+
+    #[test]
+    fn binary_layout_matches_expected_bytes_for_known_guid() {
+        #[allow(clippy::unwrap_used)]
+        let id = UserDistributionID::from_str("80E4258D-0E16-4301-B8BE-E7833D02A7AA").unwrap();
+
+        assert_eq!(
+            super::guid_to_windows_bytes(&id.0),
+            [141, 37, 228, 128, 22, 14, 1, 67, 184, 190, 231, 131, 61, 2, 167, 170,]
+        );
+    }
+}

--- a/crates/wslplugins-rs/src/utils.rs
+++ b/crates/wslplugins-rs/src/utils.rs
@@ -1,5 +1,69 @@
+use std::ffi::OsString;
+#[cfg(test)]
+use std::mem::{align_of, size_of};
+use std::os::windows::ffi::OsStringExt as _;
+use windows_core::PCWSTR;
 #[cfg(test)]
 pub fn test_transparence<T, U>() {
     assert_eq!(align_of::<T>(), align_of::<U>());
     assert_eq!(size_of::<T>(), size_of::<U>());
+}
+
+pub fn opt_wide_str(ptr: *const u16) -> Option<OsString> {
+    if ptr.is_null() {
+        None
+    } else {
+        let wide_str = PCWSTR::from_raw(ptr);
+        // SAFETY: The caller guarantees that `ptr` is valid and points to a null-terminated wide string.
+        unsafe {
+            let wide = wide_str.as_wide();
+            if wide.is_empty() {
+                None
+            } else {
+                Some(OsString::from_wide(wide))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    #[test]
+    fn test_empty_as_wide_null() {
+        let ptr = std::ptr::null();
+        assert_eq!(opt_wide_str(ptr), None);
+    }
+
+    #[test]
+    fn test_empty_as_wide_empty() {
+        let wide_str = [0u16; 1];
+        assert_eq!(opt_wide_str(wide_str.as_ptr()), None);
+    }
+
+    fn null_terminated_wide() -> impl Strategy<Value = Vec<u16>> {
+        let unit = prop_oneof![(1u16..=0xD7FF), (0xE000u16..=0xFFFF),];
+
+        proptest::collection::vec(unit, 0..100).prop_map(|wide| {
+            let mut wide: Vec<u16> = wide;
+            wide.push(0);
+            wide
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn test_opt_wide_str_non_empty(wide in null_terminated_wide()) {
+            prop_assume!(wide.len() > 1);
+
+            let ptr = wide.as_ptr();
+
+            let result = opt_wide_str(ptr);
+            #[allow(clippy::indexing_slicing, reason="Safe because we know the last element is the null terminator")]
+            let expected = OsString::from_wide(&wide[..wide.len() - 1]);
+
+            prop_assert_eq!(result, Some(expected));
+        }
+    }
 }

--- a/crates/wslplugins-rs/src/wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_distribution_information.rs
@@ -1,11 +1,11 @@
-//! # Distribution Information
+//! # WSL Distribution Information
 //!
 //! This module provides a safe abstraction for accessing information about a WSL distribution.
 //! It wraps the `WSLDistributionInformation` structure from the WSL Plugin API and implements
-//! the `CoreDistributionInformation` trait for consistent access to distribution details.
+//! the [`CoreWSLDistributionInformation`] trait for consistent access to distribution details.
 //!
 //! ## Overview
-//! The `DistributionInformation` struct provides methods to retrieve:
+//! The `WSLDistributionInformation` struct provides methods to retrieve:
 //! - Distribution ID
 //! - Distribution name
 //! - Package family name (if applicable)
@@ -17,7 +17,7 @@ use crate::api::errors::require_update_error::Error;
 use crate::api::{
     errors::require_update_error::Result, utils::check_required_version_result_from_context,
 };
-use crate::core_distribution_information::CoreDistributionInformation;
+use crate::core_wsl_distribution_information::CoreWSLDistributionInformation;
 use crate::utils::opt_wide_str;
 use crate::WSLVersion;
 use crate::{UserDistributionID, WSLContext};
@@ -33,38 +33,38 @@ use windows_core::PCWSTR;
 /// This struct wraps the `WSLDistributionInformation` from the WSL Plugin API and provides
 /// safe, idiomatic Rust access to its fields.
 #[repr(transparent)]
-pub struct DistributionInformation(wslpluginapi_sys::WSLDistributionInformation);
+pub struct WSLDistributionInformation(wslpluginapi_sys::WSLDistributionInformation);
 
-impl AsRef<DistributionInformation> for wslpluginapi_sys::WSLDistributionInformation {
+impl AsRef<WSLDistributionInformation> for wslpluginapi_sys::WSLDistributionInformation {
     #[inline]
-    fn as_ref(&self) -> &DistributionInformation {
+    fn as_ref(&self) -> &WSLDistributionInformation {
         // SAFETY: conveting this kind of ref is safe as it is transparent
-        unsafe { &*ptr::from_ref::<Self>(self).cast::<DistributionInformation>() }
+        unsafe { &*ptr::from_ref::<Self>(self).cast::<WSLDistributionInformation>() }
     }
 }
 
-impl From<DistributionInformation> for wslpluginapi_sys::WSLDistributionInformation {
+impl From<WSLDistributionInformation> for wslpluginapi_sys::WSLDistributionInformation {
     #[inline]
-    fn from(value: DistributionInformation) -> Self {
+    fn from(value: WSLDistributionInformation) -> Self {
         value.0
     }
 }
 
-impl AsRef<wslpluginapi_sys::WSLDistributionInformation> for DistributionInformation {
+impl AsRef<wslpluginapi_sys::WSLDistributionInformation> for WSLDistributionInformation {
     #[inline]
     fn as_ref(&self) -> &wslpluginapi_sys::WSLDistributionInformation {
         &self.0
     }
 }
 
-impl From<wslpluginapi_sys::WSLDistributionInformation> for DistributionInformation {
+impl From<wslpluginapi_sys::WSLDistributionInformation> for WSLDistributionInformation {
     #[inline]
     fn from(value: wslpluginapi_sys::WSLDistributionInformation) -> Self {
         Self(value)
     }
 }
 
-impl DistributionInformation {
+impl WSLDistributionInformation {
     /// Retrieves the PID of the init process.
     ///
     /// This requires API version 2.0.5 or higher. If the current API version does not meet
@@ -95,7 +95,7 @@ impl DistributionInformation {
     }
 }
 
-impl CoreDistributionInformation for DistributionInformation {
+impl CoreWSLDistributionInformation for WSLDistributionInformation {
     #[inline]
     fn id(&self) -> UserDistributionID {
         self.0.Id.into()
@@ -131,9 +131,9 @@ impl CoreDistributionInformation for DistributionInformation {
     }
 }
 
-impl<T> PartialEq<T> for DistributionInformation
+impl<T> PartialEq<T> for WSLDistributionInformation
 where
-    T: CoreDistributionInformation,
+    T: CoreWSLDistributionInformation,
 {
     /// Compares two distributions for equality based on their IDs.
     #[inline]
@@ -142,7 +142,7 @@ where
     }
 }
 
-impl Hash for DistributionInformation {
+impl Hash for WSLDistributionInformation {
     /// Computes a hash based on the distribution's ID.
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -150,7 +150,7 @@ impl Hash for DistributionInformation {
     }
 }
 
-impl Display for DistributionInformation {
+impl Display for WSLDistributionInformation {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // SAFETY: Name is known to be valid
@@ -165,10 +165,10 @@ impl Display for DistributionInformation {
     }
 }
 
-impl Debug for DistributionInformation {
+impl Debug for WSLDistributionInformation {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut dbg = f.debug_struct("DistributionInformation");
+        let mut dbg = f.debug_struct(stringify!(WSLDistributionInformation));
         dbg.field("name", &self.name())
             .field("id", &self.id())
             .field("package_family_name", &self.package_family_name())
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_layouts() {
-        test_transparence::<wslpluginapi_sys::WSLDistributionInformation, DistributionInformation>(
+        test_transparence::<wslpluginapi_sys::WSLDistributionInformation, WSLDistributionInformation>(
         );
     }
 }

--- a/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
@@ -1,4 +1,4 @@
-//! # Offline Distribution Information
+//! # WSL Offline Distribution Information
 //!
 //! This module provides an abstraction over `WslOfflineDistributionInformation` from the WSL Plugin API,
 //! offering a safe and idiomatic Rust interface for accessing offline distribution details.
@@ -7,7 +7,7 @@ use crate::{
     api::{
         errors::require_update_error::Result, utils::check_required_version_result_from_context,
     },
-    core_distribution_information::CoreDistributionInformation,
+    core_wsl_distribution_information::CoreWSLDistributionInformation,
     utils::opt_wide_str,
     UserDistributionID, WSLContext, WSLVersion,
 };
@@ -25,38 +25,46 @@ use windows_core::PCWSTR;
 /// This struct allows access to the details of an offline WSL distribution, including
 /// its ID, name, and optional package family name.
 #[repr(transparent)]
-pub struct OfflineDistributionInformation(wslpluginapi_sys::WslOfflineDistributionInformation);
+pub struct WSLOfflineDistributionInformation(wslpluginapi_sys::WslOfflineDistributionInformation);
 
-impl From<OfflineDistributionInformation> for wslpluginapi_sys::WslOfflineDistributionInformation {
+impl From<WSLOfflineDistributionInformation>
+    for wslpluginapi_sys::WslOfflineDistributionInformation
+{
     #[inline]
-    fn from(value: OfflineDistributionInformation) -> Self {
+    fn from(value: WSLOfflineDistributionInformation) -> Self {
         value.0
     }
 }
 
-impl From<wslpluginapi_sys::WslOfflineDistributionInformation> for OfflineDistributionInformation {
+impl From<wslpluginapi_sys::WslOfflineDistributionInformation>
+    for WSLOfflineDistributionInformation
+{
     #[inline]
     fn from(value: wslpluginapi_sys::WslOfflineDistributionInformation) -> Self {
         Self(value)
     }
 }
 
-impl AsRef<wslpluginapi_sys::WslOfflineDistributionInformation> for OfflineDistributionInformation {
+impl AsRef<wslpluginapi_sys::WslOfflineDistributionInformation>
+    for WSLOfflineDistributionInformation
+{
     #[inline]
     fn as_ref(&self) -> &wslpluginapi_sys::WslOfflineDistributionInformation {
         &self.0
     }
 }
 
-impl AsRef<OfflineDistributionInformation> for wslpluginapi_sys::WslOfflineDistributionInformation {
+impl AsRef<WSLOfflineDistributionInformation>
+    for wslpluginapi_sys::WslOfflineDistributionInformation
+{
     #[inline]
-    fn as_ref(&self) -> &OfflineDistributionInformation {
+    fn as_ref(&self) -> &WSLOfflineDistributionInformation {
         // SAFETY: This conversion is safe because of transparency.
-        unsafe { &*ptr::from_ref::<Self>(self).cast::<OfflineDistributionInformation>() }
+        unsafe { &*ptr::from_ref::<Self>(self).cast::<WSLOfflineDistributionInformation>() }
     }
 }
 
-impl CoreDistributionInformation for OfflineDistributionInformation {
+impl CoreWSLDistributionInformation for WSLOfflineDistributionInformation {
     #[inline]
     fn id(&self) -> UserDistributionID {
         self.0.Id.into()
@@ -85,7 +93,6 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
             WSLContext::get_current(),
             &WSLVersion::new(2, 4, 4),
         )?;
-
         Ok(opt_wide_str(self.0.Flavor))
     }
 
@@ -99,9 +106,9 @@ impl CoreDistributionInformation for OfflineDistributionInformation {
     }
 }
 
-impl<T> PartialEq<T> for OfflineDistributionInformation
+impl<T> PartialEq<T> for WSLOfflineDistributionInformation
 where
-    T: CoreDistributionInformation,
+    T: CoreWSLDistributionInformation,
 {
     /// Compares two distributions by their IDs for equality.
     #[inline]
@@ -110,7 +117,7 @@ where
     }
 }
 
-impl Hash for OfflineDistributionInformation {
+impl Hash for WSLOfflineDistributionInformation {
     /// Computes a hash based on the distribution's ID.
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -118,7 +125,7 @@ impl Hash for OfflineDistributionInformation {
     }
 }
 
-impl Display for OfflineDistributionInformation {
+impl Display for WSLOfflineDistributionInformation {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // SAFETY: Name is known to be valid
@@ -133,10 +140,10 @@ impl Display for OfflineDistributionInformation {
     }
 }
 
-impl Debug for OfflineDistributionInformation {
+impl Debug for WSLOfflineDistributionInformation {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut dbg = f.debug_struct("DistributionInformation");
+        let mut dbg = f.debug_struct(stringify!(WSLOfflineDistributionInformation));
         dbg.field("name", &self.name())
             .field("id", &self.id())
             .field("package_family_name", &self.package_family_name());
@@ -168,7 +175,7 @@ mod tests {
     fn test_layouts() {
         test_transparence::<
             wslpluginapi_sys::WslOfflineDistributionInformation,
-            OfflineDistributionInformation,
+            WSLOfflineDistributionInformation,
         >();
     }
 }

--- a/crates/wslplugins-rs/src/wsl_session_information.rs
+++ b/crates/wslplugins-rs/src/wsl_session_information.rs
@@ -3,7 +3,7 @@
 //! This module provides a safe abstraction over the `WSLSessionInformation` structure
 //! from the WSL Plugin API, allowing access to session details in an idiomatic Rust interface.
 
-use crate::SessionID;
+use crate::{HasSessionId, SessionID};
 use core::hash;
 use std::{fmt, os::windows::raw::HANDLE};
 use wslpluginapi_sys::windows_sys::Win32::Security::PSID;
@@ -50,6 +50,13 @@ impl WSLSessionInformation {
     #[inline]
     pub const unsafe fn user_sid(&self) -> PSID {
         self.0.UserSid
+    }
+}
+
+impl HasSessionId for WSLSessionInformation {
+    #[inline]
+    fn session_id(&self) -> SessionID {
+        self.id()
     }
 }
 

--- a/crates/wslplugins-rs/src/wsl_user_configuration.rs
+++ b/crates/wslplugins-rs/src/wsl_user_configuration.rs
@@ -28,10 +28,15 @@ pub mod enumflags2;
 #[cfg(feature = "flagset")]
 pub mod flagset;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Represents a WSL user configuration as an integer.
 ///
 /// This struct provides a simple wrapper around a 32-bit integer ([i32]), allowing for
 /// easy conversion to and from [i32] values and also flags depending on the enabled feature.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct WSLUserConfiguration(i32);
 

--- a/crates/wslplugins-rs/src/wsl_version.rs
+++ b/crates/wslplugins-rs/src/wsl_version.rs
@@ -4,6 +4,11 @@ use std::{
     ptr,
 };
 
+#[cfg(feature = "semver")]
+mod semver_impl;
+#[cfg(feature = "semver")]
+pub use semver_impl::SemverConversionError;
+
 /// Represents a WSL version number.
 ///
 /// This struct wraps the `WSLVersion` from the WSL Plugin API and provides
@@ -17,7 +22,7 @@ use std::{
 /// assert_eq!(version.revision(), 0);
 /// ```
 #[repr(transparent)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WSLVersion(wslpluginapi_sys::WSLVersion);
 
 impl WSLVersion {
@@ -95,7 +100,8 @@ impl From<WSLVersion> for wslpluginapi_sys::WSLVersion {
 impl AsRef<WSLVersion> for wslpluginapi_sys::WSLVersion {
     #[inline]
     fn as_ref(&self) -> &WSLVersion {
-        // SAFETY: conveting this kind of ref is safe as it is transparent
+        // SAFETY: Converting this reference is safe because `WSLVersion` is
+        // `#[repr(transparent)]` over `wslpluginapi_sys::WSLVersion`.
         unsafe { &*ptr::from_ref(self).cast::<WSLVersion>() }
     }
 }
@@ -104,13 +110,6 @@ impl AsRef<wslpluginapi_sys::WSLVersion> for WSLVersion {
     #[inline]
     fn as_ref(&self) -> &wslpluginapi_sys::WSLVersion {
         &self.0
-    }
-}
-
-impl Default for WSLVersion {
-    #[inline]
-    fn default() -> Self {
-        Self::new(1, 0, 0)
     }
 }
 
@@ -129,5 +128,16 @@ impl Debug for WSLVersion {
             .field("minor", &self.minor())
             .field("revision", &self.revision())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_transparence;
+
+    #[test]
+    fn test_layouts() {
+        test_transparence::<wslpluginapi_sys::WSLVersion, WSLVersion>();
     }
 }

--- a/crates/wslplugins-rs/src/wsl_version.rs
+++ b/crates/wslplugins-rs/src/wsl_version.rs
@@ -2,7 +2,11 @@ use std::{
     fmt::{self, Debug, Display},
     hash::Hash,
     ptr,
+    str::FromStr,
 };
+
+mod parse_error;
+pub use parse_error::WSLVersionParseError;
 
 #[cfg(feature = "semver")]
 mod semver_impl;
@@ -131,6 +135,45 @@ impl Debug for WSLVersion {
     }
 }
 
+impl FromStr for WSLVersion {
+    type Err = WSLVersionParseError;
+
+    #[inline]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "We check the length of `parts` before indexing it, so this is safe."
+    )]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if !matches!(parts.len(), 2 | 3) {
+            return Err(WSLVersionParseError::InvalidFormat {
+                input: s.to_owned(),
+            });
+        }
+
+        let major = parts[0]
+            .parse::<u32>()
+            .map_err(|_| WSLVersionParseError::InvalidMajor {
+                input: s.to_owned(),
+            })?;
+        let minor = parts[1]
+            .parse::<u32>()
+            .map_err(|_| WSLVersionParseError::InvalidMinor {
+                input: s.to_owned(),
+            })?;
+        let revision = parts
+            .get(2)
+            .map(|s| s.parse::<u32>())
+            .transpose()
+            .map_err(|_| WSLVersionParseError::InvalidRevision {
+                input: s.to_owned(),
+            })?
+            .unwrap_or(0);
+
+        Ok(Self::new(major, minor, revision))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,5 +182,53 @@ mod tests {
     #[test]
     fn test_layouts() {
         test_transparence::<wslpluginapi_sys::WSLVersion, WSLVersion>();
+    }
+
+    #[test]
+    fn test_from_str_rejects_invalid_format() {
+        let result = "2".parse::<WSLVersion>();
+
+        assert_eq!(
+            result,
+            Err(WSLVersionParseError::InvalidFormat {
+                input: "2".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_from_str_rejects_invalid_major() {
+        let result = "a.0.0".parse::<WSLVersion>();
+
+        assert_eq!(
+            result,
+            Err(WSLVersionParseError::InvalidMajor {
+                input: "a.0.0".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_from_str_rejects_invalid_minor() {
+        let result = "2.a.0".parse::<WSLVersion>();
+
+        assert_eq!(
+            result,
+            Err(WSLVersionParseError::InvalidMinor {
+                input: "2.a.0".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_from_str_rejects_invalid_revision() {
+        let result = "2.0.a".parse::<WSLVersion>();
+
+        assert_eq!(
+            result,
+            Err(WSLVersionParseError::InvalidRevision {
+                input: "2.0.a".to_owned(),
+            })
+        );
     }
 }

--- a/crates/wslplugins-rs/src/wsl_version.rs
+++ b/crates/wslplugins-rs/src/wsl_version.rs
@@ -13,6 +13,9 @@ mod semver_impl;
 #[cfg(feature = "semver")]
 pub use semver_impl::SemverConversionError;
 
+#[cfg(feature = "serde")]
+mod serde_impl;
+
 /// Represents a WSL version number.
 ///
 /// This struct wraps the `WSLVersion` from the WSL Plugin API and provides

--- a/crates/wslplugins-rs/src/wsl_version/parse_error.rs
+++ b/crates/wslplugins-rs/src/wsl_version/parse_error.rs
@@ -1,0 +1,28 @@
+use thiserror::Error;
+
+/// Errors returned when parsing a [`super::WSLVersion`] from text.
+#[allow(
+    clippy::enum_variant_names,
+    reason = "These names are more descriptive and easier to understand than the alternatives."
+)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
+pub enum WSLVersionParseError {
+    /// The version string does not follow the supported `major.minor` or
+    /// `major.minor.revision` shape.
+    #[error(
+        "invalid WSL version format: expected 'major.minor' or 'major.minor.revision', got '{input}'"
+    )]
+    InvalidFormat { input: String },
+
+    /// The major component is not a valid `u32`.
+    #[error("invalid WSL version major component in '{input}'")]
+    InvalidMajor { input: String },
+
+    /// The minor component is not a valid `u32`.
+    #[error("invalid WSL version minor component in '{input}'")]
+    InvalidMinor { input: String },
+
+    /// The revision component is not a valid `u32`.
+    #[error("invalid WSL version revision component in '{input}'")]
+    InvalidRevision { input: String },
+}

--- a/crates/wslplugins-rs/src/wsl_version/semver_impl.rs
+++ b/crates/wslplugins-rs/src/wsl_version/semver_impl.rs
@@ -1,0 +1,153 @@
+use super::WSLVersion;
+use semver::{BuildMetadata, Prerelease, Version};
+use std::num::TryFromIntError;
+use thiserror::Error;
+
+/// Errors returned when converting a [`semver::Version`] into [`WSLVersion`].
+///
+/// `WSLVersion` only models the numeric `major.minor.revision` components used
+/// by the WSL plugin API. Semantic-versioning pre-release identifiers and build
+/// metadata therefore cannot be represented and are rejected.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SemverConversionError {
+    /// The semantic version contains a pre-release identifier such as
+    /// `-alpha.1`, which has no equivalent in `WSLVersion`.
+    #[error("semantic versions with pre-release identifiers cannot be converted into WSLVersion")]
+    PrereleaseNotSupported,
+    /// The semantic version contains build metadata such as `+build.1`, which
+    /// has no equivalent in `WSLVersion`.
+    #[error("semantic versions with build metadata cannot be converted into WSLVersion")]
+    BuildMetadataNotSupported,
+    /// One of the numeric version components does not fit into the `u32`
+    /// representation used by `WSLVersion`.
+    #[error("semantic version numeric component exceeds u32 range")]
+    ComponentOutOfRange,
+}
+
+impl From<TryFromIntError> for SemverConversionError {
+    #[inline]
+    fn from(_: TryFromIntError) -> Self {
+        Self::ComponentOutOfRange
+    }
+}
+
+impl From<WSLVersion> for Version {
+    #[inline]
+    fn from(value: WSLVersion) -> Self {
+        Self {
+            major: u64::from(value.major()),
+            minor: u64::from(value.minor()),
+            patch: u64::from(value.revision()),
+            pre: Prerelease::EMPTY,
+            build: BuildMetadata::EMPTY,
+        }
+    }
+}
+
+impl TryFrom<Version> for WSLVersion {
+    type Error = SemverConversionError;
+
+    #[inline]
+    fn try_from(value: Version) -> Result<Self, Self::Error> {
+        if !value.pre.is_empty() {
+            return Err(SemverConversionError::PrereleaseNotSupported);
+        }
+
+        if !value.build.is_empty() {
+            return Err(SemverConversionError::BuildMetadataNotSupported);
+        }
+
+        Ok(Self::new(
+            u32::try_from(value.major)?,
+            u32::try_from(value.minor)?,
+            u32::try_from(value.patch)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn test_try_from_semver_version_rejects_prerelease() {
+        let semver_version = Version {
+            major: 2,
+            minor: 4,
+            patch: 4,
+            #[allow(clippy::unwrap_used, reason = "test data is valid")]
+            pre: "alpha.1".parse().unwrap(),
+            build: BuildMetadata::EMPTY,
+        };
+
+        let result = WSLVersion::try_from(semver_version);
+
+        assert_eq!(result, Err(SemverConversionError::PrereleaseNotSupported));
+    }
+
+    #[test]
+    fn test_try_from_semver_version_rejects_build_metadata() {
+        let semver_version = Version {
+            major: 2,
+            minor: 4,
+            patch: 4,
+            pre: Prerelease::EMPTY,
+            #[allow(clippy::unwrap_used, reason = "test data is valid")]
+            build: "build.1".parse().unwrap(),
+        };
+
+        let result = WSLVersion::try_from(semver_version);
+
+        assert_eq!(
+            result,
+            Err(SemverConversionError::BuildMetadataNotSupported)
+        );
+    }
+
+    #[test]
+    fn test_try_from_semver_version_rejects_out_of_range_component() {
+        let semver_version = Version::new(u64::from(u32::MAX) + 1, 0, 0);
+
+        let result = WSLVersion::try_from(semver_version);
+
+        assert_eq!(result, Err(SemverConversionError::ComponentOutOfRange));
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_into_semver_preserves_components(
+            major in any::<u32>(),
+            minor in any::<u32>(),
+            revision in any::<u32>(),
+        ) {
+            let version = WSLVersion::new(major, minor, revision);
+            let semver_version: Version = version.into();
+
+            prop_assert_eq!(semver_version.major, u64::from(major));
+            prop_assert_eq!(semver_version.minor, u64::from(minor));
+            prop_assert_eq!(semver_version.patch, u64::from(revision));
+            prop_assert_eq!(semver_version.pre, Prerelease::EMPTY);
+            prop_assert_eq!(semver_version.build, BuildMetadata::EMPTY);
+        }
+
+        #[test]
+        fn proptest_try_from_semver_roundtrip(
+            major in any::<u32>(),
+            minor in any::<u32>(),
+            patch in any::<u32>(),
+        ) {
+            let semver_version = Version::new(
+                u64::from(major),
+                u64::from(minor),
+                u64::from(patch),
+            );
+
+            prop_assert_eq!(
+                WSLVersion::try_from(semver_version),
+                Ok(WSLVersion::new(major, minor, patch))
+            );
+        }
+    }
+}

--- a/crates/wslplugins-rs/src/wsl_version/semver_impl.rs
+++ b/crates/wslplugins-rs/src/wsl_version/semver_impl.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 /// `WSLVersion` only models the numeric `major.minor.revision` components used
 /// by the WSL plugin API. Semantic-versioning pre-release identifiers and build
 /// metadata therefore cannot be represented and are rejected.
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SemverConversionError {
     /// The semantic version contains a pre-release identifier such as
     /// `-alpha.1`, which has no equivalent in `WSLVersion`.

--- a/crates/wslplugins-rs/src/wsl_version/serde_impl.rs
+++ b/crates/wslplugins-rs/src/wsl_version/serde_impl.rs
@@ -1,0 +1,57 @@
+use std::fmt;
+
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
+use crate::WSLVersion;
+
+impl Serialize for WSLVersion {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for WSLVersion {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct WSLVersionVisitor;
+
+        impl Visitor<'_> for WSLVersionVisitor {
+            type Value = WSLVersion;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("WSL version")
+            }
+
+            fn visit_str<E>(self, string: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                string.parse().map_err(Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(WSLVersionVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::WSLVersion;
+    use serde_test::{assert_tokens, Configure, Token};
+
+    #[test]
+    fn serde_version_as_semver_string() {
+        let version = WSLVersion::new(2, 4, 4);
+        assert_tokens(&version.readable(), &[Token::Str("2.4.4")]);
+    }
+}

--- a/examples/dist-info/Cargo.toml
+++ b/examples/dist-info/Cargo.toml
@@ -16,7 +16,7 @@ wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "macro",
   "bitflags",
   "tracing",
-], version = "0.1.0-beta.2" }
+], version = "0.1.0-beta.3" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"

--- a/examples/dist-info/src/lib.rs
+++ b/examples/dist-info/src/lib.rs
@@ -103,7 +103,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_started(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> PluginResult<()> {
         info!(
             "Distribution started. Sessionid= {:?}, Id={:?} Name={:}, Package={}, PidNs={}, InitPid={}",
@@ -129,7 +129,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_stopping(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> WinResult<()> {
         info!(
             "Distribution Stopping. SessionId={:?}, Id={:?} name={}, package={}, PidNs={}, InitPid={}",

--- a/examples/dist-info/src/lib.rs
+++ b/examples/dist-info/src/lib.rs
@@ -75,7 +75,7 @@ impl WSLPluginV1 for Plugin {
         match self
             .context
             .api
-            .new_command(session.id(), "/bin/cat")
+            .new_command(session, "/bin/cat")
             .with_arg("/proc/version")
             .execute()
         {
@@ -115,7 +115,7 @@ impl WSLPluginV1 for Plugin {
             // Use unknow if init_pid not available
             distribution.init_pid().map(|res| res.to_string()).unwrap_or("Unknow".to_string())
         );
-        self.log_os_release(session.id(), distribution.id().into());
+        self.log_os_release(session.id(), distribution.into());
         Ok(())
     }
 

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "macro",
-], version = "0.1.0-beta.2" }
+], version = "0.1.0-beta.3" }
 [dependencies.windows]
 workspace = true
 features = ["Win32_Foundation"]

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -41,7 +41,7 @@ impl WSLPluginV1 for Plugin {
         match self
             .context
             .api
-            .new_command(session.id(), "/bin/cat")
+            .new_command(session, "/bin/cat")
             .with_arg("/proc/version")
             .execute()
         {

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -78,7 +78,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_started(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> PluginResult<()> {
         let init_pid = distribution.init_pid()?;
         writeln!(
@@ -100,7 +100,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_stopping(
         &self,
         session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> WinResult<()> {
         let init_pid = distribution.init_pid()?;
         writeln!(
@@ -122,7 +122,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_registered(
         &self,
         session: &WSLSessionInformation,
-        distribution: &OfflineDistributionInformation,
+        distribution: &WSLOfflineDistributionInformation,
     ) -> WinResult<()> {
         write!(
             &self.log_file,
@@ -141,7 +141,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_unregistered(
         &self,
         session: &WSLSessionInformation,
-        distribution: &OfflineDistributionInformation,
+        distribution: &WSLOfflineDistributionInformation,
     ) -> WinResult<()> {
         write!(
             &self.log_file,

--- a/examples/unpackaged-distro-blacklist-policy/Cargo.toml
+++ b/examples/unpackaged-distro-blacklist-policy/Cargo.toml
@@ -16,7 +16,7 @@ wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "macro",
   "bitflags",
   "tracing",
-], version = "0.1.0-beta.2" }
+], version = "0.1.0-beta.3" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"

--- a/examples/unpackaged-distro-blacklist-policy/README.md
+++ b/examples/unpackaged-distro-blacklist-policy/README.md
@@ -4,7 +4,7 @@ This example demonstrates a WSL plugin that blocks unpackaged distributions at s
 
 It is intended as a reference for:
 - enforcing a simple host-side policy with [`wslplugins_rs`]
-- inspecting [`DistributionInformation`] when a distribution starts
+- inspecting [`WSLDistributionInformation`] when a distribution starts
 - returning a structured [`PluginError`] to deny an operation
 - emitting file-based diagnostics with [`tracing`]
 

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -62,7 +62,7 @@ impl WSLPluginV1 for Plugin {
     fn on_distribution_started(
         &self,
         _session: &WSLSessionInformation,
-        distribution: &DistributionInformation,
+        distribution: &WSLDistributionInformation,
     ) -> PluginResult<()> {
         #[allow(
             clippy::option_if_let_else,

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -68,10 +68,7 @@ impl WSLPluginV1 for Plugin {
             clippy::option_if_let_else,
             reason = "Improve readability by using if let"
         )]
-        if let Some(package_familly_name) =
-            distribution.package_family_name().filter(|s| !s.is_empty())
-        // treat empty string as no package family name see https://github.com/mveril/wslplugins-rs/issues/44
-        {
+        if let Some(package_familly_name) = distribution.package_family_name() {
             info!(
                 "Distribution {} started with package family name {:}",
                 distribution.name().display(),


### PR DESCRIPTION
## Summary

Prepare the `0.1.0-beta.3` release for the published crates.

## Changes

- Bump workspace and internal crate dependency versions from `0.1.0-beta.2` to `0.1.0-beta.3`.
- Rename distribution information types to the `WSL*` naming scheme and update examples accordingly.
- Add typed conversions and trait support for session IDs, distribution IDs, WSL versions, serde, and semver integration.
- Expand tests for distribution identifiers, WSL version parsing/conversions, serde behavior, and command argument encoding.

## Components Touched

- [X] Public API
- [ ] Proc macro
- [X] Runtime internals
- [ ] Unsafe code
- [X] Bug fix
- [X] Documentation
- [X] Examples
- [ ] CI / release workflow
- [ ] AGENTS.md instructions

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [ ] Relevant manual testing completed

CI: GitHub Actions `rust` run 314 succeeded.

## WSL / Windows Notes

No manual Windows/WSL validation recorded in the PR. The changes affect public API and examples, but no signing, registry registration, or WSL service restart validation was documented.

## Checklist

- [X] Tests added or updated when relevant
- [X] Documentation updated when relevant
- [X] Examples updated when relevant
- [X] No unrelated changes included
