### PR TITLE
Fix example macro feature

### DIFF
--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -20,7 +20,8 @@
 //! ### Example
 //!
 //! ```rust
-//! #[cfg(feature = "macro")]
+//! # #[cfg(feature = "macro")]
+//! # mod example {
 //! use wslplugins_rs::prelude::*;
 //! pub(crate) struct MyPlugin {
 //!   context: &'static WSLContext,
@@ -31,6 +32,7 @@
 //!         Ok(MyPlugin { context })
 //!     }
 //! }
+//! # }
 //! ```
 
 /// Provides interfaces for interacting with WSL plugin APIs.


### PR DESCRIPTION
## Summary

Fix the crate-level documentation example so the macro-gated sample compiles cleanly when doctests are evaluated without the `macro` feature enabled.

## Changes

- Hide the `#[cfg(feature = "macro")]` guard from the rendered example.
- Wrap the sample in a hidden module so the gated code remains syntactically complete for doctests.

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [X] Bug fix
- [X] Documentation
- [ ] Examples
- [ ] CI / release workflow
- [ ] AGENTS.md instructions

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [ ] Relevant manual testing completed

CI: GitHub Actions `rust` run 315 succeeded.

## WSL / Windows Notes

No host-affecting WSL validation required; this only changes crate documentation/doctest structure.

## Checklist

- [X] Tests added or updated when relevant
- [X] Documentation updated when relevant
- [ ] Examples updated when relevant
- [X] No unrelated changes included
