### PR TITLE
Add more professional docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@
 - [ ] Documentation
 - [ ] Examples
 - [ ] CI / release workflow
+- [ ] AGENTS.md instructions
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Do not run `cargo build --release` during routine work; release DLLs can interfe
 
 ## Coding Style & Naming Conventions
 
-Use Rust 2021 and the repository `rustfmt.toml` setting of hard tabs with width 4. Use `snake_case` for crates, modules, files, functions, methods, and variables; use `PascalCase` for public types and traits. Workspace lints deny `unwrap`, `expect`, `panic!`, `todo!`, `dbg!`, stdout/stderr printing, and process exits. Return typed errors and document unsafe blocks with `SAFETY:` comments.
+Use Rust 2021 and the repository `rustfmt.toml` settings. Use `snake_case` for crates, modules, files, functions, methods, and variables; use `PascalCase` for public types and traits. Workspace lints deny `unwrap`, `expect`, `panic!`, `todo!`, `dbg!`, stdout/stderr printing, and process exits. Return typed errors and document unsafe blocks with `SAFETY:` comments.
 
 ## Testing Guidelines
 
@@ -32,6 +32,14 @@ Changes unrelated to published libraries are not versioned and should use direct
 ## Commit Guidelines
 
 Recent commits use short imperative or descriptive subjects, often with PR numbers after merge, such as `Create unpackaged-distro-blacklist-policy example (#43)` or `Fix: offline distribution information should be public`. Keep commits focused and explain API or behavior changes in the body.
+
+## External References
+
+- `wslpluginapi-sys`: https://github.com/mveril/wslpluginapi-sys
+- WSL plugin sample: https://github.com/microsoft/wsl-plugin-sample
+- WSL repository: https://github.com/microsoft/WSL
+- WSL plugin documentation: https://learn.microsoft.com/en-us/windows/wsl/wsl-plugins
+- Microsoft WSL Plugin API NuGet package: https://www.nuget.org/packages/Microsoft.WSL.PluginApi
 
 ## Security & Configuration Tips
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This is a Cargo workspace for Rust WSL plugins. The main crate is `crates/wslplugins-rs`; API wrappers are in `src/api/`, plugin traits in `src/plugin/`, core WSL types in `src/`, and benchmarks in `benches/`. Macro code is split across `crates/wslplugins-macro` and `crates/wslplugins-macro-core`; macro tests are in `crates/wslplugins-macro-tests/tests/`. Example plugins live under `examples/`.
+
+For new modules, prefer modern Rust layout: create `src/foo.rs` with children under `src/foo/` instead of adding new `src/foo/mod.rs` files. Leave existing `mod.rs` files alone unless refactoring that module deliberately.
+
+## Build, Test, and Development Commands
+
+- `cargo build --workspace --all-features`: build all crates without release DLLs.
+- `cargo test --workspace --all-features`: run unit, integration, and macro tests.
+- `cargo clippy --workspace --all-targets --all-features`: run workspace lints.
+- `cargo fmt --all -- --check`: verify formatting only.
+
+Do not run `cargo build --release` during routine work; release DLLs can interfere with local WSL plugin workflows. Run `cargo publish --workspace --dry-run` only on `release/*` branches for published-crate release validation.
+
+## Coding Style & Naming Conventions
+
+Use Rust 2021 and the repository `rustfmt.toml` setting of hard tabs with width 4. Use `snake_case` for crates, modules, files, functions, methods, and variables; use `PascalCase` for public types and traits. Workspace lints deny `unwrap`, `expect`, `panic!`, `todo!`, `dbg!`, stdout/stderr printing, and process exits. Return typed errors and document unsafe blocks with `SAFETY:` comments.
+
+## Testing Guidelines
+
+Place ordinary Rust tests next to the code or in crate-level `tests/` directories. Macro behavior belongs in `crates/wslplugins-macro-tests/tests/`, with UI fixtures under `tests/ui/`. Name tests after behavior, for example `formats_user_distribution_id_as_guid`. Run the full workspace test command before opening a pull request that changes code.
+
+## Git Flow & Pull Requests
+
+Git Flow applies to published library crates: `develop` carries versioned crate work, while `main` remains the stable branch. Create `feature/*` and `fix/*` branches from `develop`, and target their pull requests back to `develop`. Use `release/*` branches for versioned release preparation, final validation, and publishing dry runs before merging to `main` and back to `develop`.
+
+Changes unrelated to published libraries are not versioned and should use direct branches targeting `main`, such as `example/*`, `doc/*`, `ci/*`, or similar focused names. Pull requests need a concise description, linked issue when applicable, test results, and Windows validation notes when signing, registry registration, or WSL service restarts are involved.
+
+## Commit Guidelines
+
+Recent commits use short imperative or descriptive subjects, often with PR numbers after merge, such as `Create unpackaged-distro-blacklist-policy example (#43)` or `Fix: offline distribution information should be public`. Keep commits focused and explain API or behavior changes in the body.
+
+## Security & Configuration Tips
+
+Do not commit private certificates, keys, signed DLLs, or machine-specific registry paths. Treat `sign-plugin.ps1 -Trust`, registry edits, and WSL service restarts as host-affecting operations.
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+## Our Standards
+
+This project aims to keep technical discussion focused, respectful, and useful.
+
+Examples of expected behavior:
+
+- Be clear and constructive when discussing code, design, and tradeoffs.
+- Assume good intent, while still asking for evidence when technical claims need support.
+- Keep reviews focused on correctness, maintainability, safety, and user impact.
+- Respect different experience levels and operating environments.
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or personal attacks.
+- Dismissive comments about people rather than their technical work.
+- Publishing private information without permission.
+- Repeatedly derailing technical discussions.
+
+## Enforcement
+
+Project maintainers may edit, hide, or remove comments, issues, pull requests, or other contributions that violate these standards.
+
+Serious or repeated violations may result in temporary or permanent restrictions from participating in the project.
+
+## Reporting
+
+Report conduct concerns privately to the project maintainer listed in `Cargo.toml`.
+
+Security issues should follow `SECURITY.md` instead of this document.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+Thanks for considering a contribution to WSLPlugins-rs.
+
+This repository is a Cargo workspace for Rust libraries and examples related to WSL plugins. Changes should stay focused and avoid host-affecting operations unless they are useful for the change being tested.
+
+## Branches
+
+Published library work follows Git Flow:
+
+- Start feature and fix branches from `develop`.
+- Target library pull requests back to `develop`.
+- Use `release/*` branches for versioned release preparation and final validation.
+- Keep `main` as the stable branch.
+
+Changes that are not part of the published libraries can use direct focused branches targeting `main`, such as `doc/*`, `ci/*`, or `example/*`.
+
+## Development
+
+Use Rust 2021 and the repository formatting settings.
+
+Before submitting a pull request, run the relevant checks:
+
+```powershell
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features
+cargo test --workspace --all-features
+```
+
+Do not run `cargo build --release` during routine library work. Release DLLs can interfere with local WSL plugin workflows.
+
+Only run:
+
+```powershell
+cargo publish --workspace --dry-run
+```
+
+from `release/*` branches during release validation.
+
+## Code Style
+
+- Use `snake_case` for crates, modules, files, functions, methods, and variables.
+- Use `PascalCase` for public types and traits.
+- Return typed errors instead of panicking.
+- Do not use `unwrap`, `expect`, `panic!`, `todo!`, `dbg!`, stdout/stderr printing, or process exits in library code.
+- Document unsafe blocks with a `SAFETY:` comment.
+
+## Tests
+
+Place ordinary Rust tests next to the implementation or in crate-level `tests/` directories.
+
+Macro behavior belongs in `crates/wslplugins-macro-tests/tests/`, with UI fixtures under `tests/ui/`.
+
+Name tests after behavior, for example:
+
+```text
+formats_user_distribution_id_as_guid
+```
+
+## Pull Requests
+
+Good pull request descriptions usually include:
+
+- A concise description of the change.
+- API, behavior, or compatibility changes, when relevant.
+- Test results for the checks that were run.
+- Windows validation notes when the change was actually tested with WSL.
+
+Keep commits focused. Recent commit subjects use short imperative or descriptive wording, for example:
+
+```text
+Fix offline distribution information visibility
+```
+
+## Security
+
+Do not commit private certificates, private keys, signed DLLs, machine-specific registry paths, or local secrets.
+
+Treat `sign-plugin.ps1 -Trust`, registry edits, and WSL service restarts as host-affecting operations. Mention them in pull requests when they are part of the validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,14 @@ Published library work follows Git Flow:
 
 Changes that are not part of the published libraries can use direct focused branches targeting `main`, such as `doc/*`, `ci/*`, or `example/*`.
 
+## External References
+
+- `wslpluginapi-sys`: https://github.com/mveril/wslpluginapi-sys
+- WSL plugin sample: https://github.com/microsoft/wsl-plugin-sample
+- WSL repository: https://github.com/microsoft/WSL
+- WSL plugin documentation: https://learn.microsoft.com/en-us/windows/wsl/wsl-plugins
+- Microsoft WSL Plugin API NuGet package: https://www.nuget.org/packages/Microsoft.WSL.PluginApi
+
 ## Development
 
 Use Rust 2021 and the repository formatting settings.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,19 @@ Install the following tools on Windows:
 Notes:
 
 - `SignTool.exe` is easiest to access from a Visual Studio Developer Command Prompt or a shell where the Windows SDK tools are on `PATH`.
-- Running the signing step with `-Trust` requires administrator privileges because it installs the generated certificate locally.
+- `sign-plugin.ps1` requires an elevated PowerShell session.
+- Running the signing step with `-Trust` installs the generated certificate into the local machine trusted root store.
 
-## Crates
+## Workspace Overview
 
-- `wslplugins-rs`: main framework crate
-- `wslplugins-macro`: procedural macro crate re-exported by `wslplugins-rs` when the `macro` feature is enabled
+The workspace is organized around a small public API surface and separate macro implementation crates:
+
+- `wslplugins-rs`: the main framework crate, with safe wrappers around the WSL plugin API, shared plugin context, typed identifiers, and plugin traits.
+- `wslplugins-macro`: the procedural macro crate re-exported by `wslplugins-rs` when the `macro` feature is enabled.
+- `wslplugins-macro-core`: the internal parsing and code generation implementation used by the procedural macro.
+- `wslplugins-macro-tests`: compile-time tests for macro-generated plugin code.
+
+This split keeps plugin authors focused on `wslplugins-rs`, while the macro parsing and generated WSL entry-point wiring stay isolated in internal crates.
 
 ## Quick Start
 
@@ -132,6 +139,12 @@ or:
 
 If you do not want to install the certificate automatically, omit `-Trust`.
 
+Microsoft's WSL plugin documentation also requires Windows test signing for test-signed plugin DLLs. If WSL rejects a locally signed plugin with `TRUST_E_NOSIGNATURE`, enable test signing on the test machine and reboot if required:
+
+```powershell
+Bcdedit.exe -set TESTSIGNING ON
+```
+
 ## Registering the Plugin in WSL
 
 Register the signed DLL in the WSL plugins registry key:
@@ -142,11 +155,11 @@ reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" /v min
 
 Adjust the registry value name and DLL path for the plugin you want to load.
 
-Restart the WSL service after registration:
+Restart the WSL service after registration, then run a WSL command to load the plugin:
 
-```cmd
-sc.exe stop wslservice
-sc.exe start wslservice
+```powershell
+Stop-Service -Name "wslservice" -Force
+wsl.exe echo "test"
 ```
 
 ## Verification
@@ -172,7 +185,9 @@ cargo publish --workspace --dry-run
 
 ## Contributing
 
-Contributions are welcome. Open an issue or submit a pull request with tests and a clear description of the change.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for branch, validation, and pull request guidance.
+
+Please report security issues privately. See [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are handled on the currently maintained development and release branches.
+
+For published crates, report vulnerabilities against the latest released version unless the issue is only present on an unreleased branch.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for a suspected vulnerability.
+
+Report security issues privately through GitHub Security Advisories when available, or contact the maintainer listed in [Cargo.toml](Cargo.toml).
+
+Include as much detail as possible:
+
+- Affected crate, example, script, or workflow.
+- Reproduction steps.
+- Expected and actual behavior.
+- Impact on plugin loading, signing, WSL sessions, command execution, or Windows host state.
+- Whether the issue requires administrator privileges.
+
+## Scope
+
+Security-sensitive areas include:
+
+- WSL plugin entry points and hook wiring.
+- Unsafe blocks and FFI boundaries.
+- Command execution through WSL APIs.
+- DLL signing and certificate handling.
+- Registry registration under WSL plugin keys.
+- WSL service restart workflows.
+- CI or release automation that publishes crates or artifacts.
+
+## Host-Affecting Operations
+
+The following operations affect the host machine and should be treated carefully:
+
+- Running `sign-plugin.ps1 -Trust`.
+- Installing or trusting certificates.
+- Editing Windows registry keys.
+- Stopping or starting the WSL service.
+- Loading locally built plugin DLLs into WSL.
+
+Do not commit private certificates, private keys, signed DLLs, or machine-specific registry paths.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -10,7 +10,7 @@ Most plugin crates should depend on `wslplugins-rs` with the `macro` feature ena
 
 ```toml
 [dependencies]
-wslplugins-rs = { version = "0.1.0-beta.2", features = ["macro"] }
+wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
 ```
 
 The `macro` feature provides the `#[wsl_plugin_v1(...)]` attribute used to generate the WSL plugin entry points.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,58 @@
+# Building Plugins with WSLPlugins-rs
+
+WSLPlugins-rs helps plugin authors build WSL plugin DLLs in Rust.
+
+This page is for users of the library. If you want to contribute to this repository, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Dependency
+
+Most plugin crates should depend on `wslplugins-rs` with the `macro` feature enabled.
+
+```toml
+[dependencies]
+wslplugins-rs = { version = "0.1.0-beta.2", features = ["macro"] }
+```
+
+The `macro` feature provides the `#[wsl_plugin_v1(...)]` attribute used to generate the WSL plugin entry points.
+
+## Minimal Shape
+
+Implement `WSLPluginV1` for your plugin type, then annotate the implementation with the WSL API version your plugin targets.
+
+```rust
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct MyPlugin {
+	context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 0, 5)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+The macro generates the exported functions expected by WSL.
+
+## Reliability
+
+WSL loads plugin code into the WSL service process. If a plugin crashes, it can crash the WSL service.
+
+For that reason:
+
+- Prefer returning errors over panicking.
+- Avoid `panic!`, `unwrap`, and `expect` in plugin code.
+- Keep unsafe code narrow and document why each unsafe block is valid.
+- Be careful with blocking work inside plugin hooks.
+
+## Examples
+
+Start with the included examples:
+
+- `examples/minimal`: a close Rust translation of Microsoft's sample plugin.
+- `examples/dist-info`: an example focused on distribution metadata and tracing.
+- `examples/unpackaged-distro-blacklist-policy`: an example policy plugin.
+
+See [signing.md](signing.md) for local DLL signing and [windows-validation.md](windows-validation.md) for testing a plugin on a Windows host.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,39 @@
+# Release Process
+
+This project uses Git Flow for published library crates.
+
+## Branches
+
+- `develop` carries versioned crate work.
+- `release/*` branches are used for release preparation and validation.
+- `main` remains the stable branch.
+
+Changes unrelated to published libraries can use focused branches targeting `main`, such as `doc/*`, `ci/*`, or `example/*`.
+
+## Validation
+
+Run the full validation set before publishing:
+
+```powershell
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features
+cargo test --workspace --all-features
+```
+
+On `release/*` branches, also run:
+
+```powershell
+cargo publish --workspace --dry-run
+```
+
+Do not run release validation from routine feature branches.
+
+## Windows Notes
+
+When a release changes plugin loading, signing, registry registration, or WSL service behavior, add a short note about what was tested manually.
+
+Relevant notes include:
+
+- WSL version.
+- Plugin example tested.
+- Any host-affecting validation, such as certificate trust, registry edits, or WSL service restarts.

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -1,0 +1,45 @@
+# Signing WSL Plugin DLLs
+
+WSL plugin DLLs must be signed before they can be loaded through the local WSL plugin registration flow.
+
+This repository provides [sign-plugin.ps1](../sign-plugin.ps1) for local development signing.
+
+## Prerequisites
+
+Install the following tools on Windows:
+
+- PowerShell
+- OpenSSL
+- `SignTool.exe` from the Windows SDK
+
+`SignTool.exe` is easiest to use from a Visual Studio Developer Command Prompt, or from a shell where the Windows SDK tools are on `PATH`.
+
+## Local Signing
+
+Open an elevated PowerShell session, build the plugin DLL, then sign it:
+
+```powershell
+.\sign-plugin.ps1 -PluginPath .\target\release\minimal.dll
+```
+
+To also trust the generated certificate locally:
+
+```powershell
+.\sign-plugin.ps1 -PluginPath .\target\release\minimal.dll -Trust
+```
+
+The script requires administrator privileges. The `-Trust` option also imports the certificate into the local machine trusted root store.
+
+Microsoft's WSL plugin documentation also requires Windows test signing for test-signed plugin DLLs. If WSL rejects a locally signed plugin with `TRUST_E_NOSIGNATURE`, enable test signing on the test machine and reboot if required:
+
+```powershell
+Bcdedit.exe -set TESTSIGNING ON
+```
+
+## Security Notes
+
+Do not commit private certificates, private keys, or signed DLLs.
+
+The script's default `cert.pfx` output is for local testing and is ignored by Git. Do not use a generated local test certificate for real signing or distribution.
+
+When a pull request changes signing behavior, mention any manual signing or trust-store change that was used for validation.

--- a/docs/windows-validation.md
+++ b/docs/windows-validation.md
@@ -1,0 +1,44 @@
+# Windows and WSL Validation
+
+Some changes require validation on a Windows host with WSL installed.
+
+## When to Validate Manually
+
+Manual validation is relevant when a change affects:
+
+- Plugin DLL loading.
+- DLL signing.
+- Certificate trust.
+- Registry registration.
+- WSL service restart behavior.
+- WSL command execution.
+- Session, distribution, or VM metadata.
+
+## Suggested Notes
+
+When manual Windows validation is relevant, keep the notes short. The most useful details are:
+
+- WSL version.
+- Plugin example tested.
+- Anything host-affecting, such as trusting a certificate, editing the registry, or restarting `wslservice`.
+
+## Registry Registration
+
+Register plugin DLLs under:
+
+```text
+HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins
+```
+
+Use machine-specific paths only in local commands or pull request notes. Do not commit machine-specific registry paths to source files.
+
+## Service Restart
+
+After registration changes, restart the WSL service:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+wsl.exe echo "test"
+```
+
+This affects the host machine, so it is useful to mention when it was part of manual validation.


### PR DESCRIPTION
## Summary

Add more complete repository documentation and contribution guidance for WSLPlugins-rs.

## Changes

- Add repository guidance in `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md`.
- Add focused docs for plugin development, signing, release flow, and Windows/WSL validation.
- Update the README with clearer workspace overview, signing notes, service restart guidance, and contribution/security links.
- Extend the pull request template with an `AGENTS.md instructions` component checkbox.

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [X] Documentation
- [ ] Examples
- [ ] CI / release workflow
- [X] AGENTS.md instructions

## Validation

- [X] `cargo test --workspace --all-features`
- [X] `cargo clippy --workspace --all-targets --all-features`
- [X] `cargo fmt --all -- --check`
- [ ] Relevant manual testing completed

CI: GitHub Actions `rust` run 323 succeeded.

## WSL / Windows Notes

No host-affecting WSL validation required; this is documentation and repository guidance only.

## Checklist

- [ ] Tests added or updated when relevant
- [X] Documentation updated when relevant
- [ ] Examples updated when relevant
- [X] No unrelated changes included
