### PR TITLE
Add WSL version capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ quote = "1"
 syn = "2"
 proc-macro2 = "1"
 smallvec = "1" 
+strum = { version = "0.28", features = ["derive"] }
 
 [workspace.package]
 authors = ["Mickaël Véril <mika.veril@wanadoo.fr>"]

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pub(crate) struct MyPlugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -88,6 +88,56 @@ impl WSLPluginV1 for MyPlugin {
 ```
 
 The `macro` feature re-exports the `wsl_plugin_v1` attribute and generates the WSL entry points for a `WSLPluginV1` implementation.
+
+### Choosing the Required API Version
+
+The macro argument controls the minimum WSL Plugin API version checked before
+your plugin is initialized:
+
+```rust
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct MyPlugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for MyPlugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+Use `#[wsl_plugin_v1]` when the plugin only needs the base entry point and no
+specific API capability. Use `#[wsl_plugin_v1(major, minor)]` or
+`#[wsl_plugin_v1(major, minor, revision)]` when the whole plugin requires a
+known API version before it can run.
+
+For plugins that require named API capabilities, pass one or more
+`WSLVersionCapability` values:
+
+```rust
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct RegistrationLogger {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(
+    WSLVersionCapability::DistributionRegisteredHook
+    | WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for RegistrationLogger {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+Hooks introduced after the base API, such as distribution registration and
+unregistration notifications, are wired only when the host API version supports
+the corresponding capability.
 
 ## Running Commands in WSL
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ impl WSLPluginV1 for MyPlugin {
 
 The `macro` feature re-exports the `wsl_plugin_v1` attribute and generates the WSL entry points for a `WSLPluginV1` implementation.
 
-### Choosing the Required API Version
+### Choosing API Requirements
 
-The macro argument controls the minimum WSL Plugin API version checked before
-your plugin is initialized:
+The macro argument controls the WSL Plugin API support checked before your plugin is initialized.
+Use no argument when the plugin only needs the base entry point:
 
 ```rust
 use wslplugins_rs::prelude::*;
@@ -101,7 +101,7 @@ pub(crate) struct MyPlugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 1, 2)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -109,10 +109,8 @@ impl WSLPluginV1 for MyPlugin {
 }
 ```
 
-Use `#[wsl_plugin_v1]` when the plugin only needs the base entry point and no
-specific API capability. Use `#[wsl_plugin_v1(major, minor)]` or
-`#[wsl_plugin_v1(major, minor, revision)]` when the whole plugin requires a
-known API version before it can run.
+Use `#[wsl_plugin_v1(major, minor)]` or `#[wsl_plugin_v1(major, minor, revision)]` when the whole
+plugin requires a known API version before it can run.
 
 For plugins that require named API capabilities, pass one or more
 `WSLVersionCapability` values:
@@ -137,7 +135,9 @@ impl WSLPluginV1 for RegistrationLogger {
 
 Hooks introduced after the base API, such as distribution registration and
 unregistration notifications, are wired only when the host API version supports
-the corresponding capability.
+the corresponding capability. See the book's
+[Version Capabilities](https://mveril.github.io/wslplugins-rs/version-capabilities.html) chapter
+for the capability list and cross-references to command execution and plugin events.
 
 ## Running Commands in WSL
 
@@ -162,16 +162,19 @@ Notes:
 
 - Program paths must be Linux UTF-8 paths such as `/bin/echo`
 - `argv[0]` defaults to the program path and can be overridden with `with_arg0`
-- `with_distribution_id` targets a specific user distribution
+- `with_distribution_id` targets a specific user distribution and requires the
+  `ExecuteBinaryInDistribution` capability
 - `execute()` returns a `TcpStream` connected to process stdin/stdout
 - stderr is forwarded to Linux `dmesg`
 
 ## Examples
 
-Two example plugins are included:
+Example plugins are included:
 
 - `examples/minimal`: a close Rust translation of Microsoft's sample plugin
 - `examples/dist-info`: a plugin focused on distribution metadata and tracing
+- `examples/unpackaged-distro-blacklist-policy`: a policy plugin that blocks unpackaged
+  distributions
 
 Build one of them in release mode:
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [End-to-End Quickstart](./quickstart.md)
 - [Your First Plugin](./first-plugin.md)
 - [WSL Plugin Model](./wsl-plugin-model.md)
+- [Version Capabilities](./version-capabilities.md)
 - [Error Handling](./error-handling.md)
 - [Command Execution](./command-execution.md)
 - [FFI and Safety](./ffi-and-safety.md)

--- a/book/src/command-execution.md
+++ b/book/src/command-execution.md
@@ -38,7 +38,11 @@ root filesystem backed by writable `tmpfs`, so changes made there disappear when
 down.
 
 Use a user-distribution target when the command must run inside a distribution rather than the root
-namespace. That path uses `ExecuteBinaryInDistribution`, which requires API version `2.1.2` or newer.
+namespace. That path uses `ExecuteBinaryInDistribution`, which is represented by
+`WSLVersionCapability::ExecuteBinaryInDistribution`; see
+[Version Capabilities](./version-capabilities.md) for the required API support. If that command path
+is central to the plugin, declare the capability in `#[wsl_plugin_v1(...)]`. If it is optional,
+handle the error returned by `execute()`.
 
 The returned `TcpStream` is connected to the command's stdin and stdout. It does not carry stderr;
 WSL sends stderr output to Linux `dmesg`.

--- a/book/src/command-execution.md
+++ b/book/src/command-execution.md
@@ -39,10 +39,9 @@ down.
 
 Use a user-distribution target when the command must run inside a distribution rather than the root
 namespace. That path uses `ExecuteBinaryInDistribution`, which is represented by
-`WSLVersionCapability::ExecuteBinaryInDistribution`; see
-[Version Capabilities](./version-capabilities.md) for the required API support. If that command path
-is central to the plugin, declare the capability in `#[wsl_plugin_v1(...)]`. If it is optional,
-handle the error returned by `execute()`.
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`). If that command path is central to the plugin, declare the capability in
+`#[wsl_plugin_v1(...)]`. If it is optional, handle the error returned by `execute()`.
 
 The returned `TcpStream` is connected to the command's stdin and stdout. It does not carry stderr;
 WSL sends stderr output to Linux `dmesg`.

--- a/book/src/ffi-and-safety.md
+++ b/book/src/ffi-and-safety.md
@@ -50,9 +50,8 @@ keep these header-level rules in mind:
 - hook input pointers are valid only during the callback;
 - string pointers from WSL may be null where the header allows it, such as `PackageFamilyName`;
 - `ExecuteBinary` argument arrays are null-terminated at the ABI boundary;
-- `WSLDistributionInformation::InitPid` was introduced in API version `2.0.5`;
-- `Flavor` and `Version` exist in the current header; `wslplugins-rs` exposes them through
-  `flavor()` and `version()` and currently requires API version `2.4.4` before reading them.
+- some fields and function pointers are available only when the host API supports the matching
+  `WSLVersionCapability`; see [Version Capabilities](./version-capabilities.md).
 
 These details are useful when debugging ABI mismatches, but ordinary plugin logic should stay on the
 typed Rust side.

--- a/book/src/first-plugin.md
+++ b/book/src/first-plugin.md
@@ -2,7 +2,7 @@
 
 The minimal shape of a plugin is a Rust `cdylib` crate containing a type plus an implementation of
 `WSLPluginV1`.
-The `#[wsl_plugin_v1(...)]` macro generates the exported functions and hook wiring expected by WSL.
+The `#[wsl_plugin_v1]` macro generates the exported functions and hook wiring expected by WSL.
 
 ```rust
 # extern crate wslplugins_rs;
@@ -12,7 +12,7 @@ pub(crate) struct MyPlugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -20,9 +20,9 @@ impl WSLPluginV1 for MyPlugin {
 }
 ```
 
-The version in `#[wsl_plugin_v1(major, minor, revision)]` declares the WSL plugin API version
-required by the plugin. The revision component is optional and defaults to `0`. Use the lowest
-version that provides the hooks and API calls your plugin needs.
+Use a requirement in `#[wsl_plugin_v1(...)]` only when the whole plugin depends on a specific WSL
+Plugin API version or named capability. See [Version Capabilities](./version-capabilities.md) for
+the supported forms and feature gates.
 
 The `context` gives access to the framework API wrapper. Store it if the plugin needs to call WSL
 APIs later from hook methods.
@@ -43,7 +43,7 @@ pub(crate) struct MyPlugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 1, 2)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -71,7 +71,8 @@ impl WSLPluginV1 for MyPlugin {
 ```
 
 Command paths are Linux paths such as `/bin/cat`. `execute()` returns a `TcpStream` connected to the
-process stdin and stdout; stderr is forwarded to Linux `dmesg`.
+process stdin and stdout; stderr is forwarded to Linux `dmesg`. This example runs in the VM root
+namespace; see [Command Execution](./command-execution.md) for distribution-scoped execution.
 
 ## Start from an Example
 
@@ -81,8 +82,9 @@ demonstrates:
 - creating plugin state in `try_new`;
 - logging VM and distribution lifecycle events;
 - running `/bin/cat /proc/version` when the VM starts;
-- using `#[wsl_plugin_v1(2, 1, 3)]` because it handles distribution registration hooks. Those
-  hooks are available starting with API version `2.1.2`; the example currently targets `2.1.3`.
+- using the macro to declare plugin-wide requirements when a hook or API capability is mandatory.
+  New plugins should prefer named capabilities where available; see
+  [Version Capabilities](./version-capabilities.md).
 
 In your own plugin crate, the equivalent release build is:
 
@@ -92,5 +94,5 @@ cargo build --release
 
 After that, sign and register the DLL as described in the packaging chapter.
 
-Next: read [WSL Plugin Model](./wsl-plugin-model.md) for the host model and versioning rules, or
+Next: read [WSL Plugin Model](./wsl-plugin-model.md) for the host model and available events, or
 jump to [Packaging and Deployment](./packaging.md) when you are ready to load the DLL into WSL.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -69,7 +69,7 @@ pub(crate) struct Plugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -79,6 +79,10 @@ impl WSLPluginV1 for Plugin {
 
 Add hook methods only for the events your plugin handles. The default implementation for each hook
 does nothing and returns success.
+
+If a hook or API call is mandatory for the plugin, declare that requirement with
+`#[wsl_plugin_v1(...)]`. Prefer named capabilities where they exist; see
+[Version Capabilities](./version-capabilities.md).
 
 ## Validate During Development
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -16,7 +16,7 @@ reference, use the generated Rust documentation on docs.rs.
 The framework keeps the plugin authoring model small:
 
 - implement `WSLPluginV1` for a Rust type that owns the plugin state;
-- annotate the implementation with `#[wsl_plugin_v1(...)]`;
+- annotate the implementation with `#[wsl_plugin_v1]` or a specific API requirement;
 - use typed wrappers for WSL sessions, distributions, versions, and command execution;
 - return errors instead of panicking inside the WSL service process.
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -38,7 +38,7 @@ pub(crate) struct Plugin {
     _context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { _context: context })

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -111,21 +111,13 @@ Windows errors.
 
 ## Runtime API Is Too Old
 
-If the plugin requests a newer API version than WSL provides, initialization fails with
-`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+If the plugin requests a newer API version or capability than WSL provides, initialization fails
+with `WSL_E_PLUGIN_REQUIRES_UPDATE`.
 
-Use the version in `#[wsl_plugin_v1(major, minor, revision)]` as the minimum API version for the
-plugin as a whole. Keep it as low as practical, and use runtime `Result` checks for optional fields
-or optional behavior.
-
-Common version-sensitive features include:
-
-| Feature | Minimum API version |
-| --- | --- |
-| `init_pid()` | `2.0.5` |
-| Distribution registration hooks | `2.1.2` |
-| `ExecuteBinaryInDistribution` | `2.1.2` |
-| `flavor()` and `version()` | `2.4.4` |
+Use `#[wsl_plugin_v1(...)]` for requirements that are mandatory for the plugin as a whole. Keep the
+requirement as low as practical, and use runtime `Result` checks for optional fields or optional
+behavior. The capability list and minimum API versions are centralized in
+[Version Capabilities](./version-capabilities.md).
 
 ## Cleanup After a Bad Deployment
 

--- a/book/src/version-capabilities.md
+++ b/book/src/version-capabilities.md
@@ -1,0 +1,145 @@
+# Version Capabilities
+
+WSL Plugin API features are introduced over time. `wslplugins-rs` models those feature gates with
+`WSLVersionCapability`, so plugin code can name the API feature it depends on instead of hard-coding
+the version number everywhere.
+
+Use capabilities when the crate exposes one for the feature you need. Use an explicit version only
+when the plugin depends on an API surface that does not yet have a named capability. The capability
+matrix below is the canonical list for this book; other chapters link here instead of repeating it.
+
+## Capability Reference
+
+| Capability | Enables | Minimum API version |
+| --- | --- | --- |
+| `DistributionInitPid` | `WSLDistributionInformation::init_pid()` | `2.0.5` |
+| `DistributionRegisteredHook` | `on_distribution_registered` hook wiring | `2.1.2` |
+| `DistributionUnregisteredHook` | `on_distribution_unregistered` hook wiring | `2.1.2` |
+| `ExecuteBinaryInDistribution` | command execution inside a user distribution | `2.1.2` |
+| `DistributionFlavor` | `CoreWSLDistributionInformation::flavor()` | `2.4.4` |
+| `DistributionVersion` | `CoreWSLDistributionInformation::version()` | `2.4.4` |
+
+For command execution details, see [Command Execution](./command-execution.md). For the lifecycle
+and registration events exposed by `WSLPluginV1`, see [WSL Plugin Model](./wsl-plugin-model.md).
+
+## Plugin Requirements
+
+The `#[wsl_plugin_v1]` macro checks the plugin-wide API requirement before `try_new` runs:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct Plugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1]
+impl WSLPluginV1 for Plugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+No argument means the plugin only requires the base entry point. If the whole plugin needs a known
+minimum API version, pass that version explicitly:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(2, 1)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+The revision component is optional and defaults to `0`:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+When a named capability exists, prefer it:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(WSLVersionCapability::ExecuteBinaryInDistribution)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+Capabilities can be combined with `|`. The macro uses the highest minimum API version required by
+the listed capabilities:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(
+    WSLVersionCapability::DistributionRegisteredHook
+        | WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+If the host WSL Plugin API is too old for the plugin-wide requirement, initialization fails with
+`WSL_E_PLUGIN_REQUIRES_UPDATE`. WSL does not call `try_new`, and the hook table is not registered
+for that plugin.
+
+## Runtime Checks
+
+Plugin-wide requirements are the right choice when the plugin cannot behave correctly without the
+feature. Optional features should stay as runtime `Result` checks:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> {
+    distribution
+        .flavor()
+        .ok()
+        .flatten()
+        .map(|value| value.to_string_lossy().into_owned())
+}
+```
+
+The same rule applies to command execution. If distribution-scoped command execution is central to
+the plugin, declare `WSLVersionCapability::ExecuteBinaryInDistribution` in `#[wsl_plugin_v1(...)]`.
+If it is optional, handle the API error returned by `execute()`.
+
+## Inspecting Versions
+
+`WSLVersionCapability::required_version()` returns the minimum API version for one capability.
+`WSLVersion::supports(capability)` checks whether a runtime API version supports a capability, and
+`WSLVersion::capabilities()` iterates over the capabilities supported by that version.
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::{WSLVersion, WSLVersionCapability};
+
+let version = WSLVersion::new(2, 1, 2);
+
+assert!(version.supports(WSLVersionCapability::ExecuteBinaryInDistribution));
+```

--- a/book/src/version-capabilities.md
+++ b/book/src/version-capabilities.md
@@ -12,12 +12,12 @@ matrix below is the canonical list for this book; other chapters link here inste
 
 | Capability | Enables | Minimum API version |
 | --- | --- | --- |
-| `DistributionInitPid` | `WSLDistributionInformation::init_pid()` | `2.0.5` |
-| `DistributionRegisteredHook` | `on_distribution_registered` hook wiring | `2.1.2` |
-| `DistributionUnregisteredHook` | `on_distribution_unregistered` hook wiring | `2.1.2` |
-| `ExecuteBinaryInDistribution` | command execution inside a user distribution | `2.1.2` |
-| `DistributionFlavor` | `CoreWSLDistributionInformation::flavor()` | `2.4.4` |
-| `DistributionVersion` | `CoreWSLDistributionInformation::version()` | `2.4.4` |
+| <a id="distribution-init-pid"></a>`DistributionInitPid` | `WSLDistributionInformation::init_pid()` | `2.0.5` |
+| <a id="distribution-registered-hook"></a>`DistributionRegisteredHook` | `on_distribution_registered` hook wiring | `2.1.2` |
+| <a id="distribution-unregistered-hook"></a>`DistributionUnregisteredHook` | `on_distribution_unregistered` hook wiring | `2.1.2` |
+| <a id="execute-binary-in-distribution"></a>`ExecuteBinaryInDistribution` | command execution inside a user distribution | `2.1.2` |
+| <a id="distribution-flavor"></a>`DistributionFlavor` | `CoreWSLDistributionInformation::flavor()` | `2.4.4` |
+| <a id="distribution-version"></a>`DistributionVersion` | `CoreWSLDistributionInformation::version()` | `2.4.4` |
 
 For command execution details, see [Command Execution](./command-execution.md). For the lifecycle
 and registration events exposed by `WSLPluginV1`, see [WSL Plugin Model](./wsl-plugin-model.md).
@@ -126,7 +126,9 @@ fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> 
 ```
 
 The same rule applies to command execution. If distribution-scoped command execution is central to
-the plugin, declare `WSLVersionCapability::ExecuteBinaryInDistribution` in `#[wsl_plugin_v1(...)]`.
+the plugin, declare
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`) in `#[wsl_plugin_v1(...)]`.
 If it is optional, handle the API error returned by `execute()`.
 
 ## Inspecting Versions

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -32,11 +32,12 @@ The API table contains:
 - `MountFolder`, for creating a Plan 9 mount between Windows and Linux;
 - `ExecuteBinary`, for running a program in the root namespace of the WSL2 VM;
 - `PluginError`, for passing a user-facing failure message back to WSL;
-- `ExecuteBinaryInDistribution`, introduced in API version `2.1.2`, for running a program inside a
-  user distribution.
+- `ExecuteBinaryInDistribution`, for running a program inside a user distribution when the host API
+  supports that capability.
 
 The hook table contains VM lifecycle hooks, distribution lifecycle hooks, and distribution
-registration hooks. The registration hooks were introduced in API version `2.1.2`.
+registration hooks. Registration and unregistration hooks are version-gated capabilities; see
+[Version Capabilities](./version-capabilities.md).
 
 ## Plugin State
 
@@ -71,40 +72,40 @@ The public crate provides typed wrappers for common WSL concepts:
 - `WSLVmCreationSettings`: VM creation settings.
 - `SessionID`, `DistributionID`, and `UserDistributionID`: typed identifiers.
 - `WSLVersion`: parsed WSL version values.
+- `WSLVersionCapability`: named feature gates for version-sensitive API surface.
 
 Prefer these wrappers over raw FFI types in plugin code. Raw access is available behind the `sys`
 feature for cases where a wrapper does not yet expose the needed API.
 
 Online and offline distribution wrappers both implement `CoreWSLDistributionInformation`. That gives
 common access to the distribution ID, name, optional package family name, flavor, and version. The
-crate checks the runtime API version for fields that were added later: `init_pid()` requires
-`2.0.5`, and `flavor()` / `version()` require `2.4.4`.
+crate checks the runtime API capability for fields that were added later. The capability names and
+minimum versions are listed in [Version Capabilities](./version-capabilities.md).
 
 ## Versioned Hooks
 
-Some hooks are only available in newer WSL plugin API versions. For example, distribution
-registration hooks are documented in this crate as introduced in API version `2.1.2`.
+Some hooks are only available in newer WSL plugin API versions. Distribution registration and
+unregistration are represented by `WSLVersionCapability::DistributionRegisteredHook` and
+`WSLVersionCapability::DistributionUnregisteredHook`.
 
-Choose the version passed to `#[wsl_plugin_v1(...)]` according to the hooks and API calls your
-plugin uses. A plugin that only handles basic VM lifecycle events can target an older version than a
-plugin that observes distribution registration.
+Choose the requirement passed to `#[wsl_plugin_v1(...)]` according to the hooks and API calls that
+are mandatory for the plugin. A plugin that only handles basic VM lifecycle events can use
+`#[wsl_plugin_v1]`. A plugin whose core behavior depends on registration events should declare the
+matching capability.
 
-The macro accepts `major, minor` or `major, minor, revision`. If the revision is omitted, it is
-treated as `0`.
-
-If WSL offers an older API version than the one requested by the plugin macro, initialization fails
-with `WSL_E_PLUGIN_REQUIRES_UPDATE`. This is preferable to registering callbacks that rely on fields
-or function pointers the host does not provide.
+If WSL offers an older API version than the requirement requested by the plugin macro,
+initialization fails with `WSL_E_PLUGIN_REQUIRES_UPDATE`. This is preferable when the plugin cannot
+operate correctly without that hook or API call.
 
 ## Version Checks
 
 `wslplugins-rs` uses two complementary version checks.
 
-The first check happens when WSL loads the DLL. The version passed to
-`#[wsl_plugin_v1(...)]` is the minimum API version required by the plugin as a whole. During entry
-point initialization, the generated code compares that requirement with `context.api.version()`. If
-the runtime API is too old, plugin creation stops and WSL receives
-`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+The first check happens when WSL loads the DLL. The requirement passed to `#[wsl_plugin_v1(...)]`
+is the minimum API support required by the plugin as a whole. It can be omitted, expressed as an
+explicit version, or expressed as one or more capabilities. During entry point initialization, the
+generated code compares that requirement with `context.api.version()`. If the runtime API is too
+old, plugin creation stops and WSL receives `WSL_E_PLUGIN_REQUIRES_UPDATE`.
 
 That means WSL does not call `try_new` and the hook table is not registered for that plugin. A hook
 that requires a newer API version will therefore never be called if you declare that version in the
@@ -113,8 +114,7 @@ plugin's behavior.
 
 Hook availability is decided when the plugin is registered with WSL, not lazily when an event
 happens. If the current WSL plugin API version does not provide a hook slot, the method associated
-with that event is never called. For example, on a runtime older than `2.1.2`, distribution
-registration and unregistration notifications are not available, so
+with that event is never called. For example, without the distribution registration capabilities,
 `on_distribution_registered` and `on_distribution_unregistered` cannot run.
 
 The second check happens at runtime on individual APIs or fields. Some wrappers return a `Result`
@@ -135,9 +135,8 @@ fn describe_distribution(distribution: &WSLDistributionInformation) -> PluginRes
 
 If the runtime API is too old for `init_pid()`, the call returns a `RequiresUpdate` error that maps
 to `WSL_E_PLUGIN_REQUIRES_UPDATE`. The same pattern is used by distribution-scoped command
-execution: `ExecuteBinaryInDistribution` requires API version `2.1.2`, so
-`with_distribution_id(DistributionID::User(...)).execute()` can return an API error on an older
-runtime.
+execution: `with_distribution_id(DistributionID::User(...)).execute()` requires
+`WSLVersionCapability::ExecuteBinaryInDistribution` and can return an API error on an older runtime.
 
 Use runtime `Result` checks when the feature is optional:
 
@@ -156,8 +155,9 @@ fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> 
 
 Use the macro version requirement when the plugin cannot behave correctly without the newer hook,
 field, or API call. For example, a plugin whose main purpose is to run commands inside a specific
-user distribution should require at least `2.1.2`; a plugin that only uses `flavor()` as a nicer log
-detail can keep a lower macro version and treat that field as optional.
+user distribution should require `WSLVersionCapability::ExecuteBinaryInDistribution`; a plugin that
+only uses `flavor()` as a nicer log detail can keep a lower macro requirement and treat that field
+as optional. See [Version Capabilities](./version-capabilities.md) for the full capability list.
 
 ## Hook Failure Semantics
 

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -85,8 +85,11 @@ minimum versions are listed in [Version Capabilities](./version-capabilities.md)
 ## Versioned Hooks
 
 Some hooks are only available in newer WSL plugin API versions. Distribution registration and
-unregistration are represented by `WSLVersionCapability::DistributionRegisteredHook` and
-`WSLVersionCapability::DistributionUnregisteredHook`.
+unregistration are represented by
+[`WSLVersionCapability::DistributionRegisteredHook`](./version-capabilities.md#distribution-registered-hook)
+(`2.1.2`) and
+[`WSLVersionCapability::DistributionUnregisteredHook`](./version-capabilities.md#distribution-unregistered-hook)
+(`2.1.2`).
 
 Choose the requirement passed to `#[wsl_plugin_v1(...)]` according to the hooks and API calls that
 are mandatory for the plugin. A plugin that only handles basic VM lifecycle events can use
@@ -136,7 +139,8 @@ fn describe_distribution(distribution: &WSLDistributionInformation) -> PluginRes
 If the runtime API is too old for `init_pid()`, the call returns a `RequiresUpdate` error that maps
 to `WSL_E_PLUGIN_REQUIRES_UPDATE`. The same pattern is used by distribution-scoped command
 execution: `with_distribution_id(DistributionID::User(...)).execute()` requires
-`WSLVersionCapability::ExecuteBinaryInDistribution` and can return an API error on an older runtime.
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`) and can return an API error on an older runtime.
 
 Use runtime `Result` checks when the feature is optional:
 
@@ -155,9 +159,11 @@ fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> 
 
 Use the macro version requirement when the plugin cannot behave correctly without the newer hook,
 field, or API call. For example, a plugin whose main purpose is to run commands inside a specific
-user distribution should require `WSLVersionCapability::ExecuteBinaryInDistribution`; a plugin that
-only uses `flavor()` as a nicer log detail can keep a lower macro requirement and treat that field
-as optional. See [Version Capabilities](./version-capabilities.md) for the full capability list.
+user distribution should require
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`); a plugin that only uses `flavor()` as a nicer log detail can keep a lower macro
+requirement and treat that field as optional. See [Version Capabilities](./version-capabilities.md)
+for the full capability list.
 
 ## Hook Failure Semantics
 

--- a/crates/wslplugins-macro-core/Cargo.toml
+++ b/crates/wslplugins-macro-core/Cargo.toml
@@ -14,7 +14,7 @@ syn = { workspace = true, features = ["full", "extra-traits"] }
 quote = { workspace = true }
 "proc-macro2" = { workspace = true }
 heck = "0.5"
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { workspace = true }
 
 [build-dependencies]
 wslpluginapi-sys = { workspace = true, features = ["hooks-field-names"] }

--- a/crates/wslplugins-macro-core/Cargo.toml
+++ b/crates/wslplugins-macro-core/Cargo.toml
@@ -21,5 +21,8 @@ wslpluginapi-sys = { workspace = true, features = ["hooks-field-names"] }
 quote = "1"
 struct-field-names-as-array = "0.3"
 
+[dev-dependencies]
+proptest = "1.9.0"
+
 [lints]
 workspace = true

--- a/crates/wslplugins-macro-core/src/generator/hook_field_mapping.rs
+++ b/crates/wslplugins-macro-core/src/generator/hook_field_mapping.rs
@@ -10,7 +10,7 @@ use syn::{parse_str, Ident, Lifetime, Result, Type};
 
 // Main function to generate the complete TokenStream for the plugin
 pub fn generate(imp: &ParsedImpl, version: &RequiredVersion) -> Result<TokenStream> {
-    let entry_point: TokenStream = generate_entry_point(imp, version)?;
+    let entry_point = generate_entry_point(imp, version)?;
     let hooks_funcs = generate_hook_fns(imp.hooks.as_ref())?;
     Ok(quote! {
         #entry_point
@@ -68,17 +68,34 @@ fn hook_field_mapping(hooks_struct_name: &Ident, hook: Hooks) -> Result<TokenStr
         #hooks_struct_name.#field = Some(#func);
     };
     let result = match hook {
-        Hooks::OnDistributionRegistered | Hooks::OnDistributionUnregistered => {
-            let required_version = "2.1.2";
+        Hooks::OnDistributionRegistered => {
+            let capability =
+                quote!(::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook);
             quote! {
-                if current_version >= ::wslplugins_rs::WSLVersion::new(2, 1, 2) {
+                if current_version.supports(#capability) {
                     #base
                 } else {
                     ::wslplugins_rs::__private::debug!(
                         "Hook {} not applied due to insufficient version (found: {}, required: {})",
                         #field_str,
                         current_version,
-                        #required_version
+                        #capability.required_version()
+                    );
+                }
+            }
+        }
+        Hooks::OnDistributionUnregistered => {
+            let capability =
+                quote!(::wslplugins_rs::WSLVersionCapability::DistributionUnregisteredHook);
+            quote! {
+                if current_version.supports(#capability) {
+                    #base
+                } else {
+                    ::wslplugins_rs::__private::debug!(
+                        "Hook {} not applied due to insufficient version (found: {}, required: {})",
+                        #field_str,
+                        current_version,
+                        #capability.required_version()
                     );
                 }
             }
@@ -102,11 +119,18 @@ fn generate_entry_point(imp: &ParsedImpl, version: &RequiredVersion) -> Result<T
         })
         .unwrap_or_default();
     let hook_set = prepare_hooks(&hooks_ref_name, &imp.hooks)?;
-    let RequiredVersion {
-        major,
-        minor,
-        revision,
-    } = version;
+    let create_plugin = match version {
+        RequiredVersion::Version {
+            major,
+            minor,
+            revision,
+        } => quote! {
+            ::wslplugins_rs::plugin::create_plugin_with_required_version(api, #major, #minor, #revision)?
+        },
+        RequiredVersion::Capabilities(capabilities) => quote! {
+            ::wslplugins_rs::plugin::create_plugin_with_required_capabilities(api, [#(#capabilities),*])?
+        },
+    };
 
     Ok(quote! {
         static PLUGIN: ::std::sync::OnceLock<#static_plugin_type> = ::std::sync::OnceLock::new();
@@ -126,7 +150,7 @@ fn generate_entry_point(imp: &ParsedImpl, version: &RequiredVersion) -> Result<T
             api: &'static ::wslplugins_rs::sys::WSLPluginAPIV1,
             hooks_ref: &mut ::wslplugins_rs::sys::WSLPluginHooksV1,
         ) -> ::wslplugins_rs::windows_core::Result<()> {
-            let plugin: #static_plugin_type = ::wslplugins_rs::plugin::create_plugin_with_required_version(api, #major, #minor, #revision)?;
+            let plugin: #static_plugin_type = #create_plugin;
             #current_version
             #(#hook_set)*
             PLUGIN.set(plugin).map_err(|_| ::wslplugins_rs::windows_core::Error::from(::wslplugins_rs::windows_core::HRESULT(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_ABORT)))
@@ -180,18 +204,19 @@ mod tests {
             hook_field_mapping(&hooks_struct_name, hook);
         assert_eq!(
             result.unwrap().to_string(),
-            quote!(
-                if current_version >= ::wslplugins_rs::WSLVersion::new(2, 1, 2) {
-                    hooks_struct.OnDistributionRegistered = Some(on_distribution_registered);
-                } else {
-                    ::wslplugins_rs::__private::debug!(
-                        "Hook {} not applied due to insufficient version (found: {}, required: {})",
-                        "OnDistributionRegistered",
-                        current_version,
-                        "2.1.2"
-                    );
-                }
-            )
+            quote!(if current_version
+                .supports(::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook)
+            {
+                hooks_struct.OnDistributionRegistered = Some(on_distribution_registered);
+            } else {
+                ::wslplugins_rs::__private::debug!(
+                    "Hook {} not applied due to insufficient version (found: {}, required: {})",
+                    "OnDistributionRegistered",
+                    current_version,
+                    ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook
+                        .required_version()
+                );
+            })
             .to_string()
         );
     }

--- a/crates/wslplugins-macro-core/src/parser/required_version.rs
+++ b/crates/wslplugins-macro-core/src/parser/required_version.rs
@@ -13,8 +13,23 @@ pub enum RequiredVersion {
     },
     Capabilities(Vec<ExprPath>),
 }
+
+impl Default for RequiredVersion {
+    fn default() -> Self {
+        Self::Version {
+            major: 0,
+            minor: 0,
+            revision: 0,
+        }
+    }
+}
+
 impl Parse for RequiredVersion {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
+        if input.is_empty() {
+            return Ok(Self::default());
+        }
+
         if !input.peek(LitInt) {
             let mut capabilities = vec![input.parse::<ExprPath>()?];
             while input.peek(Token![|]) {
@@ -100,6 +115,25 @@ mod tests {
                 assert_eq!(revision, 0);
             }
             RequiredVersion::Capabilities(_) => panic!("expected explicit version"),
+        }
+    }
+
+    #[test]
+    fn test_parse_empty_version_as_minimum_version() {
+        let version_tokens = quote! {};
+        let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
+
+        match parsed_version {
+            RequiredVersion::Version {
+                major,
+                minor,
+                revision,
+            } => {
+                assert_eq!(major, 0);
+                assert_eq!(minor, 0);
+                assert_eq!(revision, 0);
+            }
+            RequiredVersion::Capabilities(_) => panic!("expected minimum version"),
         }
     }
 

--- a/crates/wslplugins-macro-core/src/parser/required_version.rs
+++ b/crates/wslplugins-macro-core/src/parser/required_version.rs
@@ -81,10 +81,10 @@ mod tests {
     use syn::parse2;
 
     #[test]
+    #[allow(clippy::panick)]
     fn test_parse_valid_version_with_revision() {
         let version_tokens = quote! { 1, 2, 3 };
         let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
-
         match parsed_version {
             RequiredVersion::Version {
                 major,

--- a/crates/wslplugins-macro-core/src/parser/required_version.rs
+++ b/crates/wslplugins-macro-core/src/parser/required_version.rs
@@ -77,6 +77,7 @@ impl Parse for RequiredVersion {
 #[allow(clippy::unwrap_used, clippy::expect_used, reason = "Test code")]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use quote::quote;
     use syn::parse2;
 
@@ -217,5 +218,56 @@ mod tests {
             parsed_result.unwrap_err().to_string(),
             "unexpected additional components in version"
         );
+    }
+
+    proptest! {
+        #[test]
+        fn parse_valid_version_with_generated_components(
+            major in any::<u32>(),
+            minor in any::<u32>(),
+            revision in any::<u32>(),
+        ) {
+            let version_tokens = quote! { #major, #minor, #revision };
+            let parsed_version: RequiredVersion = parse2(version_tokens)?;
+
+            match parsed_version {
+                RequiredVersion::Version {
+                    major: parsed_major,
+                    minor: parsed_minor,
+                    revision: parsed_revision,
+                } => {
+                    prop_assert_eq!(parsed_major, major);
+                    prop_assert_eq!(parsed_minor, minor);
+                    prop_assert_eq!(parsed_revision, revision);
+                }
+                RequiredVersion::Capabilities(_) => {
+                    prop_assert!(false, "expected explicit version");
+                }
+            }
+        }
+
+        #[test]
+        fn parse_valid_version_without_generated_revision(
+            major in any::<u32>(),
+            minor in any::<u32>(),
+        ) {
+            let version_tokens = quote! { #major, #minor };
+            let parsed_version: RequiredVersion = parse2(version_tokens)?;
+
+            match parsed_version {
+                RequiredVersion::Version {
+                    major: parsed_major,
+                    minor: parsed_minor,
+                    revision,
+                } => {
+                    prop_assert_eq!(parsed_major, major);
+                    prop_assert_eq!(parsed_minor, minor);
+                    prop_assert_eq!(revision, 0);
+                }
+                RequiredVersion::Capabilities(_) => {
+                    prop_assert!(false, "expected explicit version");
+                }
+            }
+        }
     }
 }

--- a/crates/wslplugins-macro-core/src/parser/required_version.rs
+++ b/crates/wslplugins-macro-core/src/parser/required_version.rs
@@ -82,7 +82,7 @@ mod tests {
     use syn::parse2;
 
     #[test]
-    #[allow(clippy::panick)]
+    #[allow(clippy::panic)]
     fn test_parse_valid_version_with_revision() {
         let version_tokens = quote! { 1, 2, 3 };
         let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();

--- a/crates/wslplugins-macro-core/src/parser/required_version.rs
+++ b/crates/wslplugins-macro-core/src/parser/required_version.rs
@@ -1,18 +1,32 @@
 use syn::parse::{Parse, ParseStream};
-use syn::LitInt;
+use syn::{ExprPath, LitInt};
 use syn::{Result, Token};
 
 use crate::acc_syn_result;
 
 #[derive(Debug)]
-
-pub struct RequiredVersion {
-    pub major: u32,
-    pub minor: u32,
-    pub revision: u32,
+pub enum RequiredVersion {
+    Version {
+        major: u32,
+        minor: u32,
+        revision: u32,
+    },
+    Capabilities(Vec<ExprPath>),
 }
 impl Parse for RequiredVersion {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
+        if !input.peek(LitInt) {
+            let mut capabilities = vec![input.parse::<ExprPath>()?];
+            while input.peek(Token![|]) {
+                input.parse::<Token![|]>()?;
+                capabilities.push(input.parse::<ExprPath>()?);
+            }
+            if input.is_empty() {
+                return Ok(Self::Capabilities(capabilities));
+            }
+            return Err(input.error("unexpected additional tokens after capabilities"));
+        }
+
         // Result of parsing the major version to u32
         let major_lit = input.parse::<LitInt>()?;
         // Result of parsing the coma version to u32
@@ -35,7 +49,7 @@ impl Parse for RequiredVersion {
         let minor_result = minor_lit.base10_parse::<u32>();
         let revision_result = revision_lit.map_or(Ok(0), |lit| lit.base10_parse::<u32>());
         acc_syn_result!(major_result, minor_result, revision_result).map(
-            |(major, minor, revision)| Self {
+            |(major, minor, revision)| Self::Version {
                 major,
                 minor,
                 revision,
@@ -56,9 +70,18 @@ mod tests {
         let version_tokens = quote! { 1, 2, 3 };
         let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
 
-        assert_eq!(parsed_version.major, 1);
-        assert_eq!(parsed_version.minor, 2);
-        assert_eq!(parsed_version.revision, 3);
+        match parsed_version {
+            RequiredVersion::Version {
+                major,
+                minor,
+                revision,
+            } => {
+                assert_eq!(major, 1);
+                assert_eq!(minor, 2);
+                assert_eq!(revision, 3);
+            }
+            RequiredVersion::Capabilities(_) => panic!("expected explicit version"),
+        }
     }
 
     #[test]
@@ -66,9 +89,60 @@ mod tests {
         let version_tokens = quote! { 1, 2 };
         let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
 
-        assert_eq!(parsed_version.major, 1);
-        assert_eq!(parsed_version.minor, 2);
-        assert_eq!(parsed_version.revision, 0);
+        match parsed_version {
+            RequiredVersion::Version {
+                major,
+                minor,
+                revision,
+            } => {
+                assert_eq!(major, 1);
+                assert_eq!(minor, 2);
+                assert_eq!(revision, 0);
+            }
+            RequiredVersion::Capabilities(_) => panic!("expected explicit version"),
+        }
+    }
+
+    #[test]
+    fn test_parse_valid_capability() {
+        let version_tokens =
+            quote! { ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook };
+        let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
+
+        match parsed_version {
+            RequiredVersion::Version { .. } => panic!("expected capability"),
+            RequiredVersion::Capabilities(capabilities) => {
+                assert_eq!(
+                    quote!(#(#capabilities)|*).to_string(),
+                    quote!(::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook)
+                        .to_string()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_valid_capability_set() {
+        let version_tokens = quote! {
+            ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook
+            | ::wslplugins_rs::WSLVersionCapability::DistributionUnregisteredHook
+        };
+        let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
+
+        match parsed_version {
+            RequiredVersion::Version { .. } => panic!("expected capability set"),
+            RequiredVersion::Capabilities(capabilities) => {
+                assert_eq!(capabilities.len(), 2);
+                assert_eq!(
+                    quote!(#(#capabilities)|*).to_string(),
+                    quote!(
+                        ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook
+                            | ::wslplugins_rs::WSLVersionCapability::DistributionUnregisteredHook
+                    )
+                    .to_string()
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/wslplugins-macro-tests/tests/proc-macro-tests.rs
+++ b/crates/wslplugins-macro-tests/tests/proc-macro-tests.rs
@@ -4,6 +4,7 @@ mod test {
     #[test]
     fn test_macro_sucess() {
         let t = TestCases::new();
-        t.pass("tests/ui/success.rs")
+        t.pass("tests/ui/success.rs");
+        t.pass("tests/ui/success_capability.rs");
     }
 }

--- a/crates/wslplugins-macro-tests/tests/ui/success_capability.rs
+++ b/crates/wslplugins-macro-tests/tests/ui/success_capability.rs
@@ -1,0 +1,17 @@
+use windows::core::Result as WinResult;
+use wslplugins_rs::plugin::WSLPluginV1;
+use wslplugins_rs::{wsl_plugin_v1, WSLContext, WSLVersionCapability};
+
+pub(crate) struct Plugin;
+
+#[wsl_plugin_v1(
+    WSLVersionCapability::DistributionRegisteredHook
+        | WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+
+fn main() {}

--- a/crates/wslplugins-macro/src/lib.rs
+++ b/crates/wslplugins-macro/src/lib.rs
@@ -16,7 +16,9 @@ use proc_macro::TokenStream;
 ///   `major.minor.revision` minimum version.
 /// - `#[wsl_plugin_v1(capability)]` or
 ///   `#[wsl_plugin_v1(capability_a | capability_b)]`, which requires the
-///   minimum version for the listed `WSLVersionCapability` value or values.
+///   minimum version for the listed
+///   [`WSLVersionCapability`](https://docs.rs/wslplugins-rs/latest/wslplugins_rs/enum.WSLVersionCapability.html)
+///   value or values.
 ///
 /// # Minimum version example
 /// ```rust, ignore
@@ -35,6 +37,13 @@ use proc_macro::TokenStream;
 /// ```
 ///
 /// # Capability example
+///
+/// This example uses
+/// [`WSLVersionCapability::DistributionRegisteredHook`](https://docs.rs/wslplugins-rs/latest/wslplugins_rs/enum.WSLVersionCapability.html#variant.DistributionRegisteredHook)
+/// (`2.1.2`) and
+/// [`WSLVersionCapability::DistributionUnregisteredHook`](https://docs.rs/wslplugins-rs/latest/wslplugins_rs/enum.WSLVersionCapability.html#variant.DistributionUnregisteredHook)
+/// (`2.1.2`).
+///
 /// ```rust, ignore
 /// #[wsl_plugin_v1(
 ///     WSLVersionCapability::DistributionRegisteredHook

--- a/crates/wslplugins-macro/src/lib.rs
+++ b/crates/wslplugins-macro/src/lib.rs
@@ -3,10 +3,43 @@
 //! Provides procedural macros for WSL plugin development.
 use proc_macro::TokenStream;
 /// Attribute macro for WSL plugin V1.
-/// This macro should be used on impl block of `WSLPluginV1` in order to register the plugin that implement this interface
-/// # Example
-/// ``` rust, ignore
+///
+/// This macro should be used on an `impl WSLPluginV1` block to register a
+/// plugin implementation and generate the WSL Plugin API entry point.
+///
+/// The attribute accepts one of these required version forms:
+///
+/// - `#[wsl_plugin_v1]`, which does not require a specific minimum WSL Plugin
+///   API version beyond the entry point being available.
+/// - `#[wsl_plugin_v1(major, minor)]`, which requires `major.minor.0`.
+/// - `#[wsl_plugin_v1(major, minor, revision)]`, which requires the exact
+///   `major.minor.revision` minimum version.
+/// - `#[wsl_plugin_v1(capability)]` or
+///   `#[wsl_plugin_v1(capability_a | capability_b)]`, which requires the
+///   minimum version for the listed `WSLVersionCapability` value or values.
+///
+/// # Minimum version example
+/// ```rust, ignore
 /// #[wsl_plugin_v1]
+/// impl WSLPluginV1 for MyPlugin {
+///     // Implementation details
+/// }
+/// ```
+///
+/// # Explicit version example
+/// ```rust, ignore
+/// #[wsl_plugin_v1(2, 1, 3)]
+/// impl WSLPluginV1 for MyPlugin {
+///     // Implementation details
+/// }
+/// ```
+///
+/// # Capability example
+/// ```rust, ignore
+/// #[wsl_plugin_v1(
+///     WSLVersionCapability::DistributionRegisteredHook
+///     | WSLVersionCapability::DistributionUnregisteredHook
+/// )]
 /// impl WSLPluginV1 for MyPlugin {
 ///     // Implementation details
 /// }

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -25,7 +25,7 @@ wslpluginapi-sys.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }
 semver = { version = "1", optional = true }
-strum = { version = "0.28", features = ["derive"] }
+strum = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -25,6 +25,7 @@ wslpluginapi-sys.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }
 semver = { version = "1", optional = true }
+strum = { version = "0.28", features = ["derive"] }
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/crates/wslplugins-rs/src/api/api_v1.rs
+++ b/crates/wslplugins-rs/src/api/api_v1.rs
@@ -3,7 +3,7 @@ use super::Error;
 use super::{Result, WSLCommand};
 use crate::api::errors::require_update_error::Result as UpReqResult;
 use crate::api::wsl_command::IntoCowUtf8UnixPath;
-use crate::{HasSessionId, SessionID, UserDistributionID, WSLVersion};
+use crate::{HasSessionId, SessionID, UserDistributionID, WSLVersion, WSLVersionCapability};
 use std::ffi::OsStr;
 use std::fmt::{self, Debug};
 use std::mem::MaybeUninit;
@@ -182,7 +182,7 @@ impl ApiV1 {
         c_path: &[u8],
         args: &[*const u8],
     ) -> Result<TcpStream> {
-        self.check_required_version(&WSLVersion::new(2, 1, 2))?;
+        self.require_capability(WSLVersionCapability::ExecuteBinaryInDistribution)?;
         let mut socket = MaybeUninit::<WinSocket>::uninit();
         let guid: wslpluginapi_sys::windows_sys::core::GUID = distribution_id.into();
         // SAFETY: Calling ExecuteBinaryInDistribution is safe with agument correctly prepared.
@@ -232,6 +232,10 @@ impl ApiV1 {
 
     fn check_required_version(&self, version: &WSLVersion) -> UpReqResult<()> {
         check_required_version_result(self.version(), version)
+    }
+
+    fn require_capability(&self, capability: WSLVersionCapability) -> UpReqResult<()> {
+        self.check_required_version(&capability.required_version())
     }
 }
 

--- a/crates/wslplugins-rs/src/api/api_v1.rs
+++ b/crates/wslplugins-rs/src/api/api_v1.rs
@@ -24,7 +24,7 @@ use crate::DistributionID;
 
 use wslpluginapi_sys::WSLPluginAPIV1;
 
-use super::utils::check_required_version_result;
+use super::utils::check_requirement_result;
 
 /// Represents a structured interface for interacting with the `WSLPluginAPIV1` API.
 ///
@@ -230,12 +230,8 @@ impl ApiV1 {
         WSLCommand::new(self, session_id, program)
     }
 
-    fn check_required_version(&self, version: &WSLVersion) -> UpReqResult<()> {
-        check_required_version_result(self.version(), version)
-    }
-
     fn require_capability(&self, capability: WSLVersionCapability) -> UpReqResult<()> {
-        self.check_required_version(&capability.required_version())
+        check_requirement_result(self.version(), capability)
     }
 }
 

--- a/crates/wslplugins-rs/src/api/errors.rs
+++ b/crates/wslplugins-rs/src/api/errors.rs
@@ -6,7 +6,7 @@
 
 use thiserror::Error;
 pub mod require_update_error;
-pub use require_update_error::Error as RequireUpdateError;
+pub use require_update_error::{Error as RequireUpdateError, RequirementDefinition};
 use windows_core::{Error as WinError, HRESULT};
 use wslpluginapi_sys::WSL_E_PLUGIN_REQUIRES_UPDATE;
 

--- a/crates/wslplugins-rs/src/api/errors/require_update_error.rs
+++ b/crates/wslplugins-rs/src/api/errors/require_update_error.rs
@@ -5,24 +5,26 @@
 //! with WSL APIs.
 
 use crate::WSLVersion;
+mod requirement_definition;
+pub use requirement_definition::RequirementDefinition;
 use thiserror::Error;
 use windows_core::HRESULT;
 
 /// Represents an error when the current WSL version is unsupported.
 ///
 /// This error is returned when the WSL version being used does not satisfy
-/// the required version for a plugin.
+/// the required version or capabilities for a plugin.
 ///
 /// # Fields
 /// - `current_version`: The current WSL version.
-/// - `required_version`: The required WSL version.
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
-#[error("WSLVersion unsupported: current version {current_version}, required version {required_version}")]
+/// - `requirement`: The version or capabilities required by the operation.
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
+#[error("WSLVersion unsupported: current version {current_version}, required {requirement} (minimum version {})", requirement.version())]
 pub struct Error {
     /// The current version of WSL.
     pub current_version: WSLVersion,
-    /// The required version of WSL.
-    pub required_version: WSLVersion,
+    /// The version or capabilities required by the operation.
+    pub requirement: RequirementDefinition,
 }
 
 impl Error {
@@ -39,7 +41,27 @@ impl Error {
     pub const fn new(current_version: WSLVersion, required_version: WSLVersion) -> Self {
         Self {
             current_version,
-            required_version,
+            requirement: RequirementDefinition::Version(required_version),
+        }
+    }
+
+    /// Creates a new `Error` with the specified current WSL version and requirement.
+    ///
+    /// # Arguments
+    /// - `current_version`: The version currently in use.
+    /// - `requirement`: The version or capabilities required for compatibility.
+    ///
+    /// # Returns
+    /// A new instance of `Error`.
+    #[must_use]
+    #[inline]
+    pub fn from_requirement(
+        current_version: WSLVersion,
+        requirement: impl Into<RequirementDefinition>,
+    ) -> Self {
+        Self {
+            current_version,
+            requirement: requirement.into(),
         }
     }
     pub const WSL_E_PLUGIN_REQUIRES_UPDATE: HRESULT =

--- a/crates/wslplugins-rs/src/api/errors/require_update_error/requirement_definition.rs
+++ b/crates/wslplugins-rs/src/api/errors/require_update_error/requirement_definition.rs
@@ -114,6 +114,17 @@ impl Display for RequirementDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+    use proptest::sample::select;
+
+    fn arb_wsl_version() -> impl Strategy<Value = WSLVersion> {
+        (any::<u32>(), any::<u32>(), any::<u32>())
+            .prop_map(|(major, minor, revision)| WSLVersion::new(major, minor, revision))
+    }
+
+    fn arb_capability() -> impl Strategy<Value = WSLVersionCapability> {
+        select(WSLVersionCapability::iter().collect::<Vec<_>>())
+    }
 
     #[test]
     fn version_requirement_returns_explicit_version() {
@@ -139,5 +150,29 @@ mod tests {
                 WSLVersionCapability::DistributionVersion,
             ]))
         );
+    }
+
+    proptest! {
+        #[test]
+        fn version_requirement_always_returns_explicit_version(version in arb_wsl_version()) {
+            let requirement = RequirementDefinition::from(version);
+
+            prop_assert_eq!(requirement.version(), version);
+        }
+
+        #[test]
+        fn capability_requirement_returns_maximum_required_version(
+            capabilities in proptest::collection::hash_set(arb_capability(), 0..=6),
+        ) {
+            let expected = capabilities
+                .iter()
+                .copied()
+                .map(WSLVersionCapability::required_version)
+                .max()
+                .unwrap_or(WSLVersion::new(0, 0, 0));
+            let requirement = RequirementDefinition::from(capabilities);
+
+            prop_assert_eq!(requirement.version(), expected);
+        }
     }
 }

--- a/crates/wslplugins-rs/src/api/errors/require_update_error/requirement_definition.rs
+++ b/crates/wslplugins-rs/src/api/errors/require_update_error/requirement_definition.rs
@@ -1,0 +1,143 @@
+use crate::{WSLVersion, WSLVersionCapability};
+use std::collections::HashSet;
+use std::fmt::{self, Display};
+use std::hash::{Hash, Hasher};
+use strum::IntoEnumIterator as _;
+
+/// Defines what WSL Plugin API support is required.
+///
+/// A requirement can be expressed either as an explicit API version or as one
+/// or more named capabilities. Capability requirements are resolved to the
+/// highest minimum version required by the listed capabilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequirementDefinition {
+    /// Requires an explicit WSL Plugin API version.
+    Version(WSLVersion),
+    /// Requires one or more WSL Plugin API capabilities.
+    Capabilities(HashSet<WSLVersionCapability>),
+}
+
+impl RequirementDefinition {
+    /// Returns the minimum WSL Plugin API version required by this definition.
+    #[must_use]
+    #[inline]
+    pub fn version(&self) -> WSLVersion {
+        match self {
+            Self::Version(version) => *version,
+            Self::Capabilities(capabilities) => capabilities
+                .iter()
+                .copied()
+                .map(WSLVersionCapability::required_version)
+                .max()
+                .unwrap_or(WSLVersion::new(0, 0, 0)),
+        }
+    }
+}
+
+impl From<WSLVersion> for RequirementDefinition {
+    #[inline]
+    fn from(value: WSLVersion) -> Self {
+        Self::Version(value)
+    }
+}
+
+impl From<WSLVersionCapability> for RequirementDefinition {
+    #[inline]
+    fn from(value: WSLVersionCapability) -> Self {
+        Self::Capabilities(HashSet::from([value]))
+    }
+}
+
+impl From<HashSet<WSLVersionCapability>> for RequirementDefinition {
+    #[inline]
+    fn from(value: HashSet<WSLVersionCapability>) -> Self {
+        Self::Capabilities(value)
+    }
+}
+
+impl<const N: usize> From<[WSLVersionCapability; N]> for RequirementDefinition {
+    #[inline]
+    fn from(value: [WSLVersionCapability; N]) -> Self {
+        Self::Capabilities(HashSet::from(value))
+    }
+}
+
+impl FromIterator<WSLVersionCapability> for RequirementDefinition {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = WSLVersionCapability>>(iter: T) -> Self {
+        Self::Capabilities(iter.into_iter().collect())
+    }
+}
+
+impl Hash for RequirementDefinition {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Version(version) => {
+                0_u8.hash(state);
+                version.hash(state);
+            }
+            Self::Capabilities(capabilities) => {
+                1_u8.hash(state);
+                for capability in WSLVersionCapability::iter()
+                    .filter(|capability| capabilities.contains(capability))
+                {
+                    capability.hash(state);
+                }
+            }
+        }
+    }
+}
+
+impl Display for RequirementDefinition {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Version(version) => write!(f, "version {version}"),
+            Self::Capabilities(capabilities) => {
+                write!(f, "capabilities ")?;
+                for (index, capability) in WSLVersionCapability::iter()
+                    .filter(|capability| capabilities.contains(capability))
+                    .enumerate()
+                {
+                    if index > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{capability}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_requirement_returns_explicit_version() {
+        let version = WSLVersion::new(2, 1, 2);
+        let requirement = RequirementDefinition::from(version);
+
+        assert_eq!(requirement.version(), version);
+    }
+
+    #[test]
+    fn capability_requirement_returns_highest_required_version() {
+        let requirement = RequirementDefinition::from([
+            WSLVersionCapability::DistributionInitPid,
+            WSLVersionCapability::DistributionVersion,
+            WSLVersionCapability::DistributionVersion,
+        ]);
+
+        assert_eq!(requirement.version(), WSLVersion::new(2, 4, 4));
+        assert_eq!(
+            requirement,
+            RequirementDefinition::Capabilities(HashSet::from([
+                WSLVersionCapability::DistributionInitPid,
+                WSLVersionCapability::DistributionVersion,
+            ]))
+        );
+    }
+}

--- a/crates/wslplugins-rs/src/api/utils.rs
+++ b/crates/wslplugins-rs/src/api/utils.rs
@@ -10,7 +10,7 @@ use std::ffi::CString;
 use std::ptr;
 use typed_path::Utf8UnixPath;
 
-pub(crate) fn check_required_version_result(
+pub(crate) const fn check_required_version_result(
     current_version: &WSLVersion,
     required_version: &WSLVersion,
 ) -> Result<()> {

--- a/crates/wslplugins-rs/src/api/utils.rs
+++ b/crates/wslplugins-rs/src/api/utils.rs
@@ -5,8 +5,7 @@
 
 use super::errors::require_update_error::{Error, Result};
 use crate::cstring_ext::CstringExt;
-use crate::WSLContext;
-use crate::WSLVersion;
+use crate::{WSLContext, WSLVersion, WSLVersionCapability};
 use std::ffi::CString;
 use std::ptr;
 use typed_path::Utf8UnixPath;
@@ -15,7 +14,7 @@ pub(crate) fn check_required_version_result(
     current_version: &WSLVersion,
     required_version: &WSLVersion,
 ) -> Result<()> {
-    if current_version >= required_version {
+    if current_version.is_at_least(*required_version) {
         Ok(())
     } else {
         Err(Error {
@@ -33,6 +32,14 @@ pub(crate) fn check_required_version_result_from_context(
         let current_version = context.api.version();
         check_required_version_result(current_version, required_version)
     })
+}
+
+#[inline]
+pub(crate) fn check_capability_result_from_context(
+    wsl_context: Option<&WSLContext>,
+    capability: WSLVersionCapability,
+) -> Result<()> {
+    check_required_version_result_from_context(wsl_context, &capability.required_version())
 }
 #[inline]
 pub(super) fn encode_c_path(path: &Utf8UnixPath) -> Vec<u8> {

--- a/crates/wslplugins-rs/src/api/utils.rs
+++ b/crates/wslplugins-rs/src/api/utils.rs
@@ -3,7 +3,7 @@
 //! This module provides utilities to verify that the current WSL version meets the required version for plugin compatibility.
 //! It includes functions to perform version checks and unit tests to ensure correctness.
 
-use super::errors::require_update_error::{Error, Result};
+use super::errors::require_update_error::{Error, RequirementDefinition, Result};
 use crate::cstring_ext::CstringExt;
 use crate::{WSLContext, WSLVersion, WSLVersionCapability};
 use std::ffi::CString;
@@ -19,19 +19,28 @@ pub(crate) const fn check_required_version_result(
     } else {
         Err(Error {
             current_version: *current_version,
-            required_version: *required_version,
+            requirement: RequirementDefinition::Version(*required_version),
         })
     }
 }
 
-pub(crate) fn check_required_version_result_from_context(
-    wsl_context: Option<&WSLContext>,
-    required_version: &WSLVersion,
+pub(crate) fn check_requirement_result(
+    current_version: &WSLVersion,
+    requirement: impl Into<RequirementDefinition>,
 ) -> Result<()> {
-    wsl_context.map_or(Ok(()), |context| {
-        let current_version = context.api.version();
-        check_required_version_result(current_version, required_version)
-    })
+    let requirement = requirement.into();
+    match requirement {
+        RequirementDefinition::Version(version) => {
+            check_required_version_result(current_version, &version)
+        }
+        RequirementDefinition::Capabilities(_) => {
+            if current_version.is_at_least(requirement.version()) {
+                Ok(())
+            } else {
+                Err(Error::from_requirement(*current_version, requirement))
+            }
+        }
+    }
 }
 
 #[inline]
@@ -39,7 +48,10 @@ pub(crate) fn check_capability_result_from_context(
     wsl_context: Option<&WSLContext>,
     capability: WSLVersionCapability,
 ) -> Result<()> {
-    check_required_version_result_from_context(wsl_context, &capability.required_version())
+    wsl_context.map_or(Ok(()), |context| {
+        let current_version = context.api.version();
+        check_requirement_result(current_version, capability)
+    })
 }
 #[inline]
 pub(super) fn encode_c_path(path: &Utf8UnixPath) -> Vec<u8> {

--- a/crates/wslplugins-rs/src/api/utils.rs
+++ b/crates/wslplugins-rs/src/api/utils.rs
@@ -88,27 +88,11 @@ where
 mod tests {
     use super::*;
     use crate::WSLVersion;
+    use proptest::prelude::*;
 
-    /// Tests that `check_required_version_result` returns `Ok` when the current version meets the requirement.
-    #[test]
-    fn test_check_required_version_result_ok() {
-        let current_version = WSLVersion::new(2, 1, 3);
-        let required_version = WSLVersion::new(2, 1, 2);
-
-        let result = check_required_version_result(&current_version, &required_version);
-
-        assert!(result.is_ok());
-    }
-
-    /// Tests that `check_required_version_result` returns `Err` when the current version is insufficient.
-    #[test]
-    fn test_check_required_version_result_error() {
-        let current_version = WSLVersion::new(2, 1, 1);
-        let required_version = WSLVersion::new(2, 1, 2);
-
-        let result = check_required_version_result(&current_version, &required_version);
-
-        assert!(result.is_err());
+    fn arb_wsl_version() -> impl Strategy<Value = WSLVersion> {
+        (any::<u32>(), any::<u32>(), any::<u32>())
+            .prop_map(|(major, minor, revision)| WSLVersion::new(major, minor, revision))
     }
 
     #[test]
@@ -137,5 +121,17 @@ mod tests {
         assert_eq!(argv.len(), 3);
         assert_eq!(argv.iter().take_while(|ptr| !ptr.is_null()).count(), 2);
         assert!(argv.last().is_some_and(|ptr| ptr.is_null()));
+    }
+
+    proptest! {
+        #[test]
+        fn check_required_version_result_matches_version_ordering(
+            current_version in arb_wsl_version(),
+            required_version in arb_wsl_version(),
+        ) {
+            let result = check_required_version_result(&current_version, &required_version);
+
+            prop_assert_eq!(result.is_ok(), current_version.is_at_least(required_version));
+        }
     }
 }

--- a/crates/wslplugins-rs/src/api/wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command.rs
@@ -42,7 +42,7 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 /// - The execution target can be the system context or a specific distribution.
 /// - When this command targets a user distribution, execution uses the WSL
 ///   Plugin API `ExecuteBinaryInDistribution` entry and requires
-///   [`WSLVersionCapability::ExecuteBinaryInDistribution`].
+///   [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`).
 ///
 /// # Argument semantics
 ///
@@ -99,7 +99,7 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 ///
 /// In `WSLCommand`, selecting a user distribution target switches execution
 /// from `ExecuteBinary` to `ExecuteBinaryInDistribution`. That command path
-/// requires [`WSLVersionCapability::ExecuteBinaryInDistribution`], which is
+/// requires [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`), which is
 /// checked when the command is executed.
 ///
 /// ```no_run
@@ -122,7 +122,7 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 ///   [`TcpStream`] to the process stdin/stdout.
 /// - stderr is forwarded to `dmesg` on the Linux side.
 /// - The `ExecuteBinaryInDistribution` capability requirement is specific to
-///   this command execution path; it is not a general property of distribution
+///   this command execution path (`2.1.2`); it is not a general property of distribution
 ///   identifiers.
 /// - This type performs no validation of the Linux path or arguments beyond UTF-8 handling.
 #[doc(alias = "ExecuteBinary")]
@@ -289,7 +289,7 @@ impl<'a> WSLCommand<'a> {
     ///
     /// For `WSLCommand`, a user distribution target is executed through the WSL
     /// Plugin API `ExecuteBinaryInDistribution` entry. That path requires
-    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] and the check is
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`) and the check is
     /// performed during [`WSLCommandExecution::execute`].
     ///
     /// This accepts any value convertible into a [`DistributionID`], including:
@@ -309,7 +309,7 @@ impl<'a> WSLCommand<'a> {
     ///
     /// For `WSLCommand`, a user distribution target is executed through the WSL
     /// Plugin API `ExecuteBinaryInDistribution` entry. That path requires
-    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] and the check is
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`) and the check is
     /// performed during [`WSLCommandExecution::execute`].
     ///
     /// This accepts any value convertible into a [`DistributionID`], including:

--- a/crates/wslplugins-rs/src/api/wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command.rs
@@ -14,7 +14,10 @@ pub use wsl_command_execution::WSLCommandExecution;
 use smallvec::SmallVec;
 
 #[cfg(doc)]
-use crate::{api::Error as ApiError, CoreWSLDistributionInformation, UserDistributionID};
+use crate::{
+    api::Error as ApiError, CoreWSLDistributionInformation, UserDistributionID,
+    WSLVersionCapability,
+};
 mod prepared_wsl_command;
 #[cfg(not(feature = "smallvec"))]
 type ArgVec<'a> = Vec<Cow<'a, str>>;
@@ -37,6 +40,9 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 /// - Arguments are stored as `Cow<'a, str>` to minimize allocations.
 /// - `argv[0]` can be overridden; otherwise it defaults to the program path.
 /// - The execution target can be the system context or a specific distribution.
+/// - When this command targets a user distribution, execution uses the WSL
+///   Plugin API `ExecuteBinaryInDistribution` entry and requires
+///   [`WSLVersionCapability::ExecuteBinaryInDistribution`].
 ///
 /// # Argument semantics
 ///
@@ -91,6 +97,11 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 ///
 /// ## Executing in a user distribution
 ///
+/// In `WSLCommand`, selecting a user distribution target switches execution
+/// from `ExecuteBinary` to `ExecuteBinaryInDistribution`. That command path
+/// requires [`WSLVersionCapability::ExecuteBinaryInDistribution`], which is
+/// checked when the command is executed.
+///
 /// ```no_run
 /// # use wslplugins_rs::{DistributionID, UserDistributionID, SessionID};
 /// # use wslplugins_rs::api::{ApiV1, WSLCommandExecution};
@@ -110,6 +121,9 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 /// - [`WSLCommand::execute`] consumes the command and returns a connected
 ///   [`TcpStream`] to the process stdin/stdout.
 /// - stderr is forwarded to `dmesg` on the Linux side.
+/// - The `ExecuteBinaryInDistribution` capability requirement is specific to
+///   this command execution path; it is not a general property of distribution
+///   identifiers.
 /// - This type performs no validation of the Linux path or arguments beyond UTF-8 handling.
 #[doc(alias = "ExecuteBinary")]
 #[doc(alias = "ExecuteBinaryInDistribution")]
@@ -273,6 +287,11 @@ impl<'a> WSLCommand<'a> {
 
     /// Sets the distribution target (builder-style by mutable reference).
     ///
+    /// For `WSLCommand`, a user distribution target is executed through the WSL
+    /// Plugin API `ExecuteBinaryInDistribution` entry. That path requires
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] and the check is
+    /// performed during [`WSLCommandExecution::execute`].
+    ///
     /// This accepts any value convertible into a [`DistributionID`], including:
     /// - a [`DistributionID`] directly,
     /// - a [`UserDistributionID`],
@@ -287,6 +306,11 @@ impl<'a> WSLCommand<'a> {
     }
 
     /// Sets the distribution target (builder-style by value).
+    ///
+    /// For `WSLCommand`, a user distribution target is executed through the WSL
+    /// Plugin API `ExecuteBinaryInDistribution` entry. That path requires
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] and the check is
+    /// performed during [`WSLCommandExecution::execute`].
     ///
     /// This accepts any value convertible into a [`DistributionID`], including:
     /// - a [`DistributionID`] directly,

--- a/crates/wslplugins-rs/src/api/wsl_command/prepared_wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command/prepared_wsl_command.rs
@@ -3,6 +3,8 @@ use super::WSLCommand;
 use std::ffi::CString;
 use std::net::TcpStream;
 
+#[cfg(doc)]
+use crate::WSLVersionCapability;
 use crate::{
     api::{utils, ApiV1, Result as ApiResult},
     DistributionID, SessionID,
@@ -37,6 +39,10 @@ impl WSLCommandExecution for PreparedWSLCommand<'_> {
     ///
     /// - [`DistributionID::System`] uses `ExecuteBinary`.
     /// - [`DistributionID::User`] uses `ExecuteBinaryInDistribution`.
+    ///
+    /// This is `PreparedWSLCommand` execution behavior. The
+    /// `ExecuteBinaryInDistribution` path requires
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`].
     ///
     /// # Errors
     ///

--- a/crates/wslplugins-rs/src/api/wsl_command/prepared_wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command/prepared_wsl_command.rs
@@ -42,7 +42,7 @@ impl WSLCommandExecution for PreparedWSLCommand<'_> {
     ///
     /// This is `PreparedWSLCommand` execution behavior. The
     /// `ExecuteBinaryInDistribution` path requires
-    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`].
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`).
     ///
     /// # Errors
     ///

--- a/crates/wslplugins-rs/src/api/wsl_command/wsl_command_execution.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command/wsl_command_execution.rs
@@ -18,7 +18,7 @@ pub trait WSLCommandExecution {
     /// - The selected execution method depends on [`DistributionID`].
     /// - For `WSLCommand` and `PreparedWSLCommand`, a user distribution target
     ///   uses `ExecuteBinaryInDistribution`, which requires
-    ///   [`WSLVersionCapability::ExecuteBinaryInDistribution`].
+    ///   [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`).
     ///
     /// # Errors
     ///

--- a/crates/wslplugins-rs/src/api/wsl_command/wsl_command_execution.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command/wsl_command_execution.rs
@@ -2,7 +2,7 @@ use std::net::TcpStream;
 
 use crate::api::errors::Result as ApiResult;
 #[cfg(doc)]
-use crate::{api::Error as ApiError, DistributionID};
+use crate::{api::Error as ApiError, DistributionID, WSLVersionCapability};
 pub trait WSLCommandExecution {
     /// Executes the command via the underlying WSL Plugin API.
     ///
@@ -16,9 +16,14 @@ pub trait WSLCommandExecution {
     /// - The full argv passed to the API is:
     ///   `argv[0]` + all user-provided args.
     /// - The selected execution method depends on [`DistributionID`].
+    /// - For `WSLCommand` and `PreparedWSLCommand`, a user distribution target
+    ///   uses `ExecuteBinaryInDistribution`, which requires
+    ///   [`WSLVersionCapability::ExecuteBinaryInDistribution`].
     ///
     /// # Errors
     ///
-    /// Returns an [`ApiError`] if the underlying API call fails.
+    /// Returns an [`ApiError`] if the underlying API call fails, including when
+    /// the `ExecuteBinaryInDistribution` command path is selected on an API
+    /// version that does not support it.
     fn execute(&self) -> ApiResult<TcpStream>;
 }

--- a/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
@@ -9,6 +9,8 @@
 //! of a distribution. Implementing this trait allows for seamless integration with systems
 //! that need to handle multiple distributions in a consistent manner.
 
+#[cfg(doc)]
+use crate::WSLVersionCapability;
 use crate::{api::errors::require_update_error::Result, UserDistributionID};
 use std::ffi::OsString;
 
@@ -42,6 +44,8 @@ pub trait CoreWSLDistributionInformation {
 
     /// Retrieves the type of distribution (ubuntu, debian, ...), if available.
     ///
+    /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
+    ///
     /// # Returns
     /// - `Ok(Some(flavor)`: If the distribution has a flavor.
     /// - `Ok(None)`: If the distribution does not have a falvour.
@@ -51,6 +55,8 @@ pub trait CoreWSLDistributionInformation {
     fn flavor(&self) -> Result<Option<OsString>>;
 
     /// Retrieves the version of the distribution, if available
+    ///
+    /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     ///
     /// # Returns
     /// - `Ok(Some(version)`: If the distribution version is available.

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -14,8 +14,13 @@
 //!
 //! ## Usage
 //!
-//! Use the exposed modules and types to build custom WSL plugins. Conditional features like `macro`
-//! enable procedural macros for simplifying the plugin development process.
+//! Use the exposed modules and types to build custom WSL plugins. The `macro`
+//! feature enables the [`wsl_plugin_v1`] attribute, which generates the WSL
+//! Plugin API entry point and hook wiring for a [`WSLPluginV1`] implementation.
+//!
+//! The macro can be used without arguments for the base API, with an explicit
+//! minimum version, or with one or more [`WSLVersionCapability`] values when the
+//! plugin depends on named API capabilities.
 //!
 //! ### Example
 //!
@@ -26,7 +31,7 @@
 //! pub(crate) struct MyPlugin {
 //!   context: &'static WSLContext,
 //! }
-//! #[wsl_plugin_v1(2, 0, 5)]
+//! #[wsl_plugin_v1]
 //! impl WSLPluginV1 for MyPlugin {
 //!     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
 //!         Ok(MyPlugin { context })
@@ -80,7 +85,10 @@ pub use wsl_version::WSLVersionCapability;
 pub use wsl_version::{WSLVersion, WSLVersionParseError};
 
 /// Re-exports procedural macros when the `macro` feature is enabled.
-/// It allow to mark a plugin struct (that implement [`WSLPluginV1`] trait) to be easely integrated to the WSL plugin system without writing manually C code for entry point or hooks.
+///
+/// Use [`wsl_plugin_v1`] on a [`WSLPluginV1`] implementation to generate the
+/// exported WSL Plugin API entry point and hook table setup without writing the
+/// C ABI glue manually.
 #[cfg(feature = "macro")]
 pub use wslplugins_macro::wsl_plugin_v1;
 

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -76,6 +76,7 @@ mod wsl_version;
 pub use api::WSLCommandExecution;
 #[cfg(feature = "semver")]
 pub use wsl_version::SemverConversionError;
+pub use wsl_version::WSLVersionCapability;
 pub use wsl_version::{WSLVersion, WSLVersionParseError};
 
 /// Re-exports procedural macros when the `macro` feature is enabled.

--- a/crates/wslplugins-rs/src/plugin/mod.rs
+++ b/crates/wslplugins-rs/src/plugin/mod.rs
@@ -39,4 +39,7 @@ pub use wsl_plugin_v1::WSLPluginV1;
 /// A utility function to create a plugin with a specified required version.
 ///
 /// Refer to [`utils::create_plugin_with_required_version`] for more details.
-pub use utils::create_plugin_with_required_version;
+pub use utils::{
+    create_plugin_with_required_capabilities, create_plugin_with_required_capability,
+    create_plugin_with_required_version,
+};

--- a/crates/wslplugins-rs/src/plugin/utils.rs
+++ b/crates/wslplugins-rs/src/plugin/utils.rs
@@ -6,7 +6,7 @@
 use windows_core::{Error as WinError, Result as WinResult, HRESULT};
 use wslpluginapi_sys::{windows_sys::Win32::Foundation::ERROR_ALREADY_INITIALIZED, WSLPluginAPIV1};
 
-use crate::WSLContext;
+use crate::{WSLContext, WSLVersion, WSLVersionCapability};
 
 #[cfg(doc)]
 use super::Error;
@@ -53,6 +53,43 @@ pub fn create_plugin_with_required_version<T: WSLPluginV1>(
     WSLContext::init(api.as_ref())
         .ok_or_else(|| WinError::from_hresult(HRESULT::from_win32(ERROR_ALREADY_INITIALIZED)))
         .and_then(T::try_new)
+}
+
+/// Creates a WSL plugin instance with a specified required API capability.
+///
+/// # Errors
+/// Returns a Windows error if the API version is insufficient or the plugin is
+/// already initialized.
+#[inline]
+pub fn create_plugin_with_required_capability<T: WSLPluginV1>(
+    api: &'static WSLPluginAPIV1,
+    capability: WSLVersionCapability,
+) -> WinResult<T> {
+    create_plugin_with_required_capabilities(api, [capability])
+}
+
+/// Creates a WSL plugin instance with a specified set of required API capabilities.
+///
+/// The highest required version among the provided capabilities is selected.
+///
+/// # Errors
+/// Returns a Windows error if the API version is insufficient or the plugin is
+/// already initialized.
+#[inline]
+pub fn create_plugin_with_required_capabilities<T, I>(
+    api: &'static WSLPluginAPIV1,
+    capabilities: I,
+) -> WinResult<T>
+where
+    T: WSLPluginV1,
+    I: IntoIterator<Item = WSLVersionCapability>,
+{
+    let version = capabilities
+        .into_iter()
+        .map(WSLVersionCapability::required_version)
+        .max()
+        .unwrap_or(WSLVersion::new(0, 0, 0));
+    create_plugin_with_required_version(api, version.major(), version.minor(), version.revision())
 }
 
 #[expect(clippy::missing_errors_doc)]

--- a/crates/wslplugins-rs/src/plugin/utils.rs
+++ b/crates/wslplugins-rs/src/plugin/utils.rs
@@ -3,6 +3,8 @@
 //! This module provides utility functions for creating WSL plugins and handling results,
 //! enabling smooth integration with the WSL Plugin API.
 
+use std::iter::once;
+
 use windows_core::{Error as WinError, Result as WinResult, HRESULT};
 use wslpluginapi_sys::{windows_sys::Win32::Foundation::ERROR_ALREADY_INITIALIZED, WSLPluginAPIV1};
 
@@ -65,7 +67,7 @@ pub fn create_plugin_with_required_capability<T: WSLPluginV1>(
     api: &'static WSLPluginAPIV1,
     capability: WSLVersionCapability,
 ) -> WinResult<T> {
-    create_plugin_with_required_capabilities(api, [capability])
+    create_plugin_with_required_capabilities(api, once(capability))
 }
 
 /// Creates a WSL plugin instance with a specified set of required API capabilities.

--- a/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
+++ b/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
@@ -24,19 +24,34 @@ use windows_core::Result as WinResult;
 /// in the WSL plugin system. Each method corresponds to a specific event, such as the start
 /// or stop of a WSL VM or distribution.
 ///
+/// Plugin types are usually registered with the `wsl_plugin_v1` attribute macro
+/// re-exported by `wslplugins-rs` when the `macro` feature is enabled. The macro
+/// generates the exported WSL entry point, initializes [`WSLContext`], creates one
+/// plugin instance through [`WSLPluginV1::try_new`], and wires the trait methods
+/// that are implemented by the plugin.
+///
+/// The macro accepts either no argument, an explicit minimum API version, or one
+/// or more `WSLVersionCapability` values. Use no argument for plugins that only
+/// need the base entry point. Use capabilities when the plugin depends on named
+/// API features such as distribution registration hooks.
+///
 /// # Requirements
 /// - The trait is `Sized` and `Sync`, ensuring safe concurrent usage and instantiation.
 ///
 /// # Example
-/// ```rust
-/// use wslplugins_rs::{plugin::{WSLPluginV1, Result}, WSLContext, WSLSessionInformation, WSLVmCreationSettings};
+/// ```rust,ignore
+/// use wslplugins_rs::prelude::*;
+/// use wslplugins_rs::{WSLSessionInformation, WSLVmCreationSettings};
 /// use wslplugins_rs::windows_core::Result as WinResult;
 ///
-/// struct MyPlugin;
+/// struct MyPlugin {
+///     context: &'static WSLContext,
+/// }
 ///
+/// #[wsl_plugin_v1]
 /// impl WSLPluginV1 for MyPlugin {
 ///     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
-///         Ok(MyPlugin)
+///         Ok(Self { context })
 ///     }
 ///
 ///     fn on_vm_started(
@@ -44,7 +59,7 @@ use windows_core::Result as WinResult;
 ///         session: &WSLSessionInformation,
 ///         user_settings: &WSLVmCreationSettings,
 ///     ) -> Result<()> {
-///         println!("VM started");
+///         let _ = (session, user_settings);
 ///         Ok(())
 ///     }
 /// }

--- a/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
+++ b/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
@@ -165,7 +165,8 @@ pub trait WSLPluginV1: Sized + Sync {
     /// # Errors
     /// - `WinError`: If the event handling failed.
     /// # Notes
-    /// - Introduced in API version 2.1.2.
+    /// - This hook is wired only when the host API supports
+    ///   `WSLVersionCapability::DistributionRegisteredHook`.
     #[expect(
         unused_variables,
         reason = "We are on a treit with default methods that return just Ok(())"
@@ -189,7 +190,8 @@ pub trait WSLPluginV1: Sized + Sync {
     /// - `WinError`: If the event handling failed.
     ///
     /// # Notes
-    /// - Introduced in API version 2.1.2.
+    /// - This hook is wired only when the host API supports
+    ///   `WSLVersionCapability::DistributionUnregisteredHook`.
     #[expect(
         unused_variables,
         reason = "We are on a treit with default methods that return just 

--- a/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
+++ b/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
@@ -7,6 +7,8 @@
 #[cfg(doc)]
 use super::error::Error;
 use super::error::Result;
+#[cfg(doc)]
+use crate::WSLVersionCapability;
 use crate::{
     wsl_distribution_information::WSLDistributionInformation,
     wsl_offline_distribution_information::WSLOfflineDistributionInformation,
@@ -166,7 +168,7 @@ pub trait WSLPluginV1: Sized + Sync {
     /// - `WinError`: If the event handling failed.
     /// # Notes
     /// - This hook is wired only when the host API supports
-    ///   `WSLVersionCapability::DistributionRegisteredHook`.
+    ///   [`WSLVersionCapability::DistributionRegisteredHook`] (`2.1.2`).
     #[expect(
         unused_variables,
         reason = "We are on a treit with default methods that return just Ok(())"
@@ -191,7 +193,7 @@ pub trait WSLPluginV1: Sized + Sync {
     ///
     /// # Notes
     /// - This hook is wired only when the host API supports
-    ///   `WSLVersionCapability::DistributionUnregisteredHook`.
+    ///   [`WSLVersionCapability::DistributionUnregisteredHook`] (`2.1.2`).
     #[expect(
         unused_variables,
         reason = "We are on a treit with default methods that return just 

--- a/crates/wslplugins-rs/src/prelude.rs
+++ b/crates/wslplugins-rs/src/prelude.rs
@@ -19,6 +19,7 @@ pub use crate::plugin::{Error as PluginError, Result as PluginResult, WSLPluginV
 pub use crate::windows_core::{Error as WinError, Result as WinResult};
 #[cfg(feature = "semver")]
 pub use crate::SemverConversionError;
+pub use crate::WSLVersionCapability;
 pub use crate::WSLVersionParseError;
 pub use crate::{
     CoreWSLDistributionInformation, DistributionID, HasSessionId, SessionID, UserDistributionID,

--- a/crates/wslplugins-rs/src/wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_distribution_information.rs
@@ -1,7 +1,7 @@
 //! # WSL Distribution Information
 //!
 //! This module provides a safe abstraction for accessing information about a WSL distribution.
-//! It wraps the `WSLDistributionInformation` structure from the WSL Plugin API and implements
+//! It wraps the [`wslpluginapi_sys::WSLDistributionInformation`] structure from the WSL Plugin API and implements
 //! the [`CoreWSLDistributionInformation`] trait for consistent access to distribution details.
 //!
 //! ## Overview
@@ -9,7 +9,8 @@
 //! - Distribution ID
 //! - Distribution name
 //! - Package family name (if applicable)
-//! - Process ID (PID) of the init process (requires `DistributionInitPid` capability)
+//! - Process ID (PID) of the init process (requires
+//!   [`WSLVersionCapability::DistributionInitPid`] (`2.0.5`) capability)
 //! - PID namespace
 
 #[cfg(doc)]
@@ -66,8 +67,8 @@ impl From<wslpluginapi_sys::WSLDistributionInformation> for WSLDistributionInfor
 impl WSLDistributionInformation {
     /// Retrieves the PID of the init process.
     ///
-    /// This requires [`WSLVersionCapability::DistributionInitPid`]. If the current API version
-    /// does not support the capability, an error is returned.
+    /// This requires [`WSLVersionCapability::DistributionInitPid`] (`2.0.5`). If the current API
+    /// version does not support the capability, an error is returned.
     ///
     /// # Returns
     /// - `Ok(pid)`: The PID of the init process.
@@ -111,6 +112,9 @@ impl CoreWSLDistributionInformation for WSLDistributionInformation {
         opt_wide_str(self.0.PackageFamilyName)
     }
 
+    /// Retrieves the distribution flavor.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
     #[inline]
     fn flavor(&self) -> Result<Option<OsString>> {
         check_capability_result_from_context(
@@ -120,6 +124,9 @@ impl CoreWSLDistributionInformation for WSLDistributionInformation {
         Ok(opt_wide_str(self.0.Flavor))
     }
 
+    /// Retrieves the distribution version.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     #[inline]
     fn version(&self) -> Result<Option<OsString>> {
         check_capability_result_from_context(

--- a/crates/wslplugins-rs/src/wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_distribution_information.rs
@@ -9,7 +9,7 @@
 //! - Distribution ID
 //! - Distribution name
 //! - Package family name (if applicable)
-//! - Process ID (PID) of the init process (requires API version 2.0.5 or higher)
+//! - Process ID (PID) of the init process (requires `DistributionInitPid` capability)
 //! - PID namespace
 
 #[cfg(doc)]
@@ -66,13 +66,13 @@ impl From<wslpluginapi_sys::WSLDistributionInformation> for WSLDistributionInfor
 impl WSLDistributionInformation {
     /// Retrieves the PID of the init process.
     ///
-    /// This requires API version 2.0.5 or higher. If the current API version does not meet
-    /// the requirement, an error is returned.
+    /// This requires [`WSLVersionCapability::DistributionInitPid`]. If the current API version
+    /// does not support the capability, an error is returned.
     ///
     /// # Returns
     /// - `Ok(pid)`: The PID of the init process.
     /// # Errors
-    /// [Error]: If the runtime version version is insufficient.
+    /// [Error]: If the runtime API capability is insufficient.
     #[inline]
     pub fn init_pid(&self) -> Result<u32> {
         check_capability_result_from_context(

--- a/crates/wslplugins-rs/src/wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_distribution_information.rs
@@ -15,12 +15,11 @@
 #[cfg(doc)]
 use crate::api::errors::require_update_error::Error;
 use crate::api::{
-    errors::require_update_error::Result, utils::check_required_version_result_from_context,
+    errors::require_update_error::Result, utils::check_capability_result_from_context,
 };
 use crate::core_wsl_distribution_information::CoreWSLDistributionInformation;
 use crate::utils::opt_wide_str;
-use crate::WSLVersion;
-use crate::{UserDistributionID, WSLContext};
+use crate::{UserDistributionID, WSLContext, WSLVersionCapability};
 use std::ffi::OsString;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
@@ -76,9 +75,9 @@ impl WSLDistributionInformation {
     /// [Error]: If the runtime version version is insufficient.
     #[inline]
     pub fn init_pid(&self) -> Result<u32> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 0, 5),
+            WSLVersionCapability::DistributionInitPid,
         )?;
         Ok(self.0.InitPid)
     }
@@ -114,18 +113,18 @@ impl CoreWSLDistributionInformation for WSLDistributionInformation {
 
     #[inline]
     fn flavor(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionFlavor,
         )?;
         Ok(opt_wide_str(self.0.Flavor))
     }
 
     #[inline]
     fn version(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionVersion,
         )?;
         Ok(opt_wide_str(self.0.Version))
     }

--- a/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
@@ -85,6 +85,9 @@ impl CoreWSLDistributionInformation for WSLOfflineDistributionInformation {
         opt_wide_str(self.0.PackageFamilyName)
     }
 
+    /// Retrieves the distribution flavor.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
     #[inline]
     fn flavor(&self) -> Result<Option<OsString>> {
         check_capability_result_from_context(
@@ -94,6 +97,9 @@ impl CoreWSLDistributionInformation for WSLOfflineDistributionInformation {
         Ok(opt_wide_str(self.0.Flavor))
     }
 
+    /// Retrieves the distribution version.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     #[inline]
     fn version(&self) -> Result<Option<OsString>> {
         check_capability_result_from_context(

--- a/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
@@ -4,12 +4,10 @@
 //! offering a safe and idiomatic Rust interface for accessing offline distribution details.
 
 use crate::{
-    api::{
-        errors::require_update_error::Result, utils::check_required_version_result_from_context,
-    },
+    api::{errors::require_update_error::Result, utils::check_capability_result_from_context},
     core_wsl_distribution_information::CoreWSLDistributionInformation,
     utils::opt_wide_str,
-    UserDistributionID, WSLContext, WSLVersion,
+    UserDistributionID, WSLContext, WSLVersionCapability,
 };
 use std::{
     ffi::OsString,
@@ -89,18 +87,18 @@ impl CoreWSLDistributionInformation for WSLOfflineDistributionInformation {
 
     #[inline]
     fn flavor(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionFlavor,
         )?;
         Ok(opt_wide_str(self.0.Flavor))
     }
 
     #[inline]
     fn version(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionVersion,
         )?;
         Ok(opt_wide_str(self.0.Version))
     }

--- a/crates/wslplugins-rs/src/wsl_version.rs
+++ b/crates/wslplugins-rs/src/wsl_version.rs
@@ -209,6 +209,12 @@ impl FromStr for WSLVersion {
 mod tests {
     use super::*;
     use crate::utils::test_transparence;
+    use proptest::prelude::*;
+
+    fn arb_wsl_version() -> impl Strategy<Value = WSLVersion> {
+        (any::<u32>(), any::<u32>(), any::<u32>())
+            .prop_map(|(major, minor, revision)| WSLVersion::new(major, minor, revision))
+    }
 
     #[test]
     fn test_layouts() {
@@ -309,5 +315,39 @@ mod tests {
                 WSLVersionCapability::ExecuteBinaryInDistribution,
             ]
         );
+    }
+
+    proptest! {
+        #[test]
+        fn from_str_roundtrips_displayed_versions(version in arb_wsl_version()) {
+            prop_assert_eq!(version.to_string().parse::<WSLVersion>(), Ok(version));
+        }
+
+        #[test]
+        fn is_at_least_matches_derived_ordering(
+            current in arb_wsl_version(),
+            required in arb_wsl_version(),
+        ) {
+            prop_assert_eq!(current.is_at_least(required), current >= required);
+        }
+
+        #[test]
+        fn supports_matches_capability_required_version(version in arb_wsl_version()) {
+            for capability in WSLVersionCapability::iter() {
+                prop_assert_eq!(
+                    version.supports(capability),
+                    version.is_at_least(capability.required_version())
+                );
+            }
+        }
+
+        #[test]
+        fn capabilities_iterates_exactly_supported_capabilities(version in arb_wsl_version()) {
+            let expected = WSLVersionCapability::iter()
+                .filter(|capability| version.supports(*capability))
+                .collect::<Vec<_>>();
+
+            prop_assert_eq!(version.capabilities().collect::<Vec<_>>(), expected);
+        }
     }
 }

--- a/crates/wslplugins-rs/src/wsl_version.rs
+++ b/crates/wslplugins-rs/src/wsl_version.rs
@@ -96,7 +96,7 @@ impl WSLVersion {
     /// Returns `true` when this version is greater than or equal to `required_version`.
     #[must_use]
     #[inline]
-    pub const fn is_at_least(&self, required_version: WSLVersion) -> bool {
+    pub const fn is_at_least(&self, required_version: Self) -> bool {
         self.major() > required_version.major()
             || (self.major() == required_version.major()
                 && (self.minor() > required_version.minor()

--- a/crates/wslplugins-rs/src/wsl_version.rs
+++ b/crates/wslplugins-rs/src/wsl_version.rs
@@ -4,9 +4,13 @@ use std::{
     ptr,
     str::FromStr,
 };
+use strum::IntoEnumIterator;
 
 mod parse_error;
 pub use parse_error::WSLVersionParseError;
+
+mod capability;
+pub use capability::WSLVersionCapability;
 
 #[cfg(feature = "semver")]
 mod semver_impl;
@@ -87,6 +91,30 @@ impl WSLVersion {
     #[inline]
     pub const fn set_revision(&mut self, revision: u32) {
         self.0.Revision = revision;
+    }
+
+    /// Returns `true` when this version is greater than or equal to `required_version`.
+    #[must_use]
+    #[inline]
+    pub const fn is_at_least(&self, required_version: WSLVersion) -> bool {
+        self.major() > required_version.major()
+            || (self.major() == required_version.major()
+                && (self.minor() > required_version.minor()
+                    || (self.minor() == required_version.minor()
+                        && self.revision() >= required_version.revision())))
+    }
+
+    /// Returns `true` when this version supports the requested capability.
+    #[must_use]
+    #[inline]
+    pub const fn supports(&self, capability: WSLVersionCapability) -> bool {
+        self.is_at_least(capability.required_version())
+    }
+
+    /// Iterates over every capability supported by this version, ordered by required version.
+    #[inline]
+    pub fn capabilities(&self) -> impl Iterator<Item = WSLVersionCapability> + '_ {
+        WSLVersionCapability::iter().filter(|capability| self.supports(*capability))
     }
 }
 
@@ -232,6 +260,54 @@ mod tests {
             Err(WSLVersionParseError::InvalidRevision {
                 input: "2.0.a".to_owned(),
             })
+        );
+    }
+
+    #[test]
+    fn supports_capability_when_version_is_high_enough() {
+        let version = WSLVersion::new(2, 1, 2);
+
+        assert!(version.supports(WSLVersionCapability::DistributionRegisteredHook));
+    }
+
+    #[test]
+    fn rejects_capability_when_version_is_too_low() {
+        let version = WSLVersion::new(2, 1, 1);
+
+        assert!(!version.supports(WSLVersionCapability::DistributionRegisteredHook));
+    }
+
+    #[test]
+    fn capabilities_iterates_supported_capabilities_by_required_version() {
+        let version = WSLVersion::new(2, 4, 4);
+        let capabilities = version.capabilities().collect::<Vec<_>>();
+
+        assert_eq!(
+            capabilities,
+            vec![
+                WSLVersionCapability::DistributionInitPid,
+                WSLVersionCapability::DistributionRegisteredHook,
+                WSLVersionCapability::DistributionUnregisteredHook,
+                WSLVersionCapability::ExecuteBinaryInDistribution,
+                WSLVersionCapability::DistributionFlavor,
+                WSLVersionCapability::DistributionVersion,
+            ]
+        );
+    }
+
+    #[test]
+    fn capabilities_excludes_capabilities_that_require_newer_versions() {
+        let version = WSLVersion::new(2, 1, 2);
+        let capabilities = version.capabilities().collect::<Vec<_>>();
+
+        assert_eq!(
+            capabilities,
+            vec![
+                WSLVersionCapability::DistributionInitPid,
+                WSLVersionCapability::DistributionRegisteredHook,
+                WSLVersionCapability::DistributionUnregisteredHook,
+                WSLVersionCapability::ExecuteBinaryInDistribution,
+            ]
         );
     }
 }

--- a/crates/wslplugins-rs/src/wsl_version/capability.rs
+++ b/crates/wslplugins-rs/src/wsl_version/capability.rs
@@ -1,0 +1,36 @@
+use super::WSLVersion;
+use strum::EnumIter;
+
+/// WSL Plugin API capabilities that are only available from a specific API version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
+#[non_exhaustive]
+pub enum WSLVersionCapability {
+    /// Access to `WSLDistributionInformation::InitPid`.
+    DistributionInitPid,
+    /// Notification sent when a distribution is registered.
+    DistributionRegisteredHook,
+    /// Notification sent when a distribution is unregistered.
+    DistributionUnregisteredHook,
+    /// Execute a command inside a specific user distribution.
+    ExecuteBinaryInDistribution,
+    /// Access to the distribution flavor field.
+    DistributionFlavor,
+    /// Access to the distribution version field.
+    DistributionVersion,
+}
+
+impl WSLVersionCapability {
+    /// Returns the minimum WSL Plugin API version required for this capability.
+    #[must_use]
+    #[inline]
+    pub const fn required_version(self) -> WSLVersion {
+        match self {
+            Self::DistributionInitPid => WSLVersion::new(2, 0, 5),
+            Self::DistributionRegisteredHook => WSLVersion::new(2, 1, 2),
+            Self::DistributionUnregisteredHook => WSLVersion::new(2, 1, 2),
+            Self::ExecuteBinaryInDistribution => WSLVersion::new(2, 1, 2),
+            Self::DistributionFlavor => WSLVersion::new(2, 4, 4),
+            Self::DistributionVersion => WSLVersion::new(2, 4, 4),
+        }
+    }
+}

--- a/crates/wslplugins-rs/src/wsl_version/capability.rs
+++ b/crates/wslplugins-rs/src/wsl_version/capability.rs
@@ -26,11 +26,10 @@ impl WSLVersionCapability {
     pub const fn required_version(self) -> WSLVersion {
         match self {
             Self::DistributionInitPid => WSLVersion::new(2, 0, 5),
-            Self::DistributionRegisteredHook => WSLVersion::new(2, 1, 2),
-            Self::DistributionUnregisteredHook => WSLVersion::new(2, 1, 2),
-            Self::ExecuteBinaryInDistribution => WSLVersion::new(2, 1, 2),
-            Self::DistributionFlavor => WSLVersion::new(2, 4, 4),
-            Self::DistributionVersion => WSLVersion::new(2, 4, 4),
+            Self::DistributionRegisteredHook
+            | Self::DistributionUnregisteredHook
+            | Self::ExecuteBinaryInDistribution => WSLVersion::new(2, 1, 2),
+            Self::DistributionFlavor | Self::DistributionVersion => WSLVersion::new(2, 4, 4),
         }
     }
 }

--- a/crates/wslplugins-rs/src/wsl_version/capability.rs
+++ b/crates/wslplugins-rs/src/wsl_version/capability.rs
@@ -1,8 +1,10 @@
 use super::WSLVersion;
-use strum::EnumIter;
+use crate::api::errors::RequirementDefinition;
+use std::collections::HashSet;
+use strum::{Display, EnumIter};
 
 /// WSL Plugin API capabilities that are only available from a specific API version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumIter)]
 #[non_exhaustive]
 pub enum WSLVersionCapability {
     /// Access to `WSLDistributionInformation::InitPid`.
@@ -31,5 +33,45 @@ impl WSLVersionCapability {
             | Self::ExecuteBinaryInDistribution => WSLVersion::new(2, 1, 2),
             Self::DistributionFlavor | Self::DistributionVersion => WSLVersion::new(2, 4, 4),
         }
+    }
+}
+
+impl TryFrom<RequirementDefinition> for WSLVersionCapability {
+    type Error = RequirementDefinition;
+
+    #[inline]
+    fn try_from(value: RequirementDefinition) -> std::result::Result<Self, Self::Error> {
+        match value {
+            RequirementDefinition::Capabilities(capabilities) if capabilities.len() == 1 => {
+                capabilities
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| RequirementDefinition::Capabilities(HashSet::new()))
+            }
+            requirement => Err(requirement),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_capability_requirement_can_be_recovered() {
+        let capability = WSLVersionCapability::ExecuteBinaryInDistribution;
+        let requirement = RequirementDefinition::from(capability);
+
+        assert_eq!(WSLVersionCapability::try_from(requirement), Ok(capability));
+    }
+
+    #[test]
+    fn multi_capability_requirement_cannot_be_recovered_as_single_capability() {
+        let requirement = RequirementDefinition::from([
+            WSLVersionCapability::DistributionRegisteredHook,
+            WSLVersionCapability::DistributionUnregisteredHook,
+        ]);
+
+        assert!(WSLVersionCapability::try_from(requirement).is_err());
     }
 }

--- a/crates/wslplugins-rs/src/wsl_version/capability.rs
+++ b/crates/wslplugins-rs/src/wsl_version/capability.rs
@@ -7,17 +7,17 @@ use strum::{Display, EnumIter};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumIter)]
 #[non_exhaustive]
 pub enum WSLVersionCapability {
-    /// Access to `WSLDistributionInformation::InitPid`.
+    /// Access to `WSLDistributionInformation::InitPid` (`2.0.5`).
     DistributionInitPid,
-    /// Notification sent when a distribution is registered.
+    /// Notification sent when a distribution is registered (`2.1.2`).
     DistributionRegisteredHook,
-    /// Notification sent when a distribution is unregistered.
+    /// Notification sent when a distribution is unregistered (`2.1.2`).
     DistributionUnregisteredHook,
-    /// Execute a command inside a specific user distribution.
+    /// Execute a command inside a specific user distribution (`2.1.2`).
     ExecuteBinaryInDistribution,
-    /// Access to the distribution flavor field.
+    /// Access to the distribution flavor field (`2.4.4`).
     DistributionFlavor,
-    /// Access to the distribution version field.
+    /// Access to the distribution version field (`2.4.4`).
     DistributionVersion,
 }
 

--- a/crates/wslplugins-rs/src/wsl_version/capability.rs
+++ b/crates/wslplugins-rs/src/wsl_version/capability.rs
@@ -56,6 +56,12 @@ impl TryFrom<RequirementDefinition> for WSLVersionCapability {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+    use strum::IntoEnumIterator as _;
+
+    fn arb_capability() -> impl Strategy<Value = WSLVersionCapability> {
+        prop::sample::select(WSLVersionCapability::iter().collect::<Vec<_>>())
+    }
 
     #[test]
     fn single_capability_requirement_can_be_recovered() {
@@ -73,5 +79,14 @@ mod tests {
         ]);
 
         assert!(WSLVersionCapability::try_from(requirement).is_err());
+    }
+
+    proptest! {
+        #[test]
+        fn single_capability_requirement_roundtrips(capability in arb_capability()) {
+            let requirement = RequirementDefinition::from(capability);
+
+            prop_assert_eq!(WSLVersionCapability::try_from(requirement), Ok(capability));
+        }
     }
 }

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -36,9 +36,10 @@ impl WSLPluginV1 for MyPlugin {
 
 The macro generates the exported functions expected by WSL, initializes the shared `WSLContext`, creates one plugin instance by calling `try_new`, and wires implemented hook methods into the WSL hook table.
 
-## Required API Version
+## API Requirements
 
-The macro can also check that the host WSL Plugin API is new enough before the plugin is initialized.
+The macro can also check that the host WSL Plugin API supports the version or capability required
+before the plugin is initialized.
 
 Use no argument when the plugin only needs the base entry point:
 
@@ -97,6 +98,9 @@ impl WSLPluginV1 for MyPlugin {
 ```
 
 If the version check fails, WSL receives `WSL_E_PLUGIN_REQUIRES_UPDATE` and the plugin is not initialized.
+
+The complete capability list is maintained in the book's
+[Version Capabilities](../book/src/version-capabilities.md) chapter.
 
 ## Version-Gated Hooks
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -13,11 +13,11 @@ Most plugin crates should depend on `wslplugins-rs` with the `macro` feature ena
 wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
 ```
 
-The `macro` feature provides the `#[wsl_plugin_v1(...)]` attribute used to generate the WSL plugin entry points.
+The `macro` feature provides the `#[wsl_plugin_v1]` attribute used to generate the WSL plugin entry points.
 
 ## Minimal Shape
 
-Implement `WSLPluginV1` for your plugin type, then annotate the implementation with the WSL API version your plugin targets.
+Implement `WSLPluginV1` for your plugin type, then annotate the implementation.
 
 ```rust
 use wslplugins_rs::prelude::*;
@@ -26,7 +26,7 @@ pub(crate) struct MyPlugin {
 	context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
 	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
 		Ok(Self { context })
@@ -34,7 +34,77 @@ impl WSLPluginV1 for MyPlugin {
 }
 ```
 
-The macro generates the exported functions expected by WSL.
+The macro generates the exported functions expected by WSL, initializes the shared `WSLContext`, creates one plugin instance by calling `try_new`, and wires implemented hook methods into the WSL hook table.
+
+## Required API Version
+
+The macro can also check that the host WSL Plugin API is new enough before the plugin is initialized.
+
+Use no argument when the plugin only needs the base entry point:
+
+```rust
+#[wsl_plugin_v1]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+Use an explicit version when the whole plugin depends on a specific minimum API version:
+
+```rust
+#[wsl_plugin_v1(2, 1)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+```rust
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+Use named capabilities when the plugin depends on specific API features:
+
+```rust
+#[wsl_plugin_v1(WSLVersionCapability::DistributionRegisteredHook)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+Multiple capabilities can be combined with `|`. The macro requires the highest WSL version needed by the listed capabilities:
+
+```rust
+#[wsl_plugin_v1(
+	WSLVersionCapability::DistributionRegisteredHook
+	| WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+If the version check fails, WSL receives `WSL_E_PLUGIN_REQUIRES_UPDATE` and the plugin is not initialized.
+
+## Version-Gated Hooks
+
+Some hook fields are available only on newer WSL Plugin API versions. For example, distribution registration and unregistration hooks require the matching `WSLVersionCapability`.
+
+When a plugin implements one of these hooks, the generated entry point checks the host API version before writing that hook into the hook table. On older hosts, the plugin can still initialize, but the unsupported hook is skipped.
+
+If the plugin cannot operate correctly without those hooks, list the capability in `#[wsl_plugin_v1(...)]` so initialization fails on unsupported hosts.
 
 ## Reliability
 

--- a/examples/dist-info/src/lib.rs
+++ b/examples/dist-info/src/lib.rs
@@ -55,7 +55,7 @@ fn setup_logging() -> WinResult<()> {
     Ok(())
 }
 
-#[wsl_plugin_v1(wslplugins_rs::WSLVersionCapability::ExecuteBinaryInDistribution)]
+#[wsl_plugin_v1(WSLVersionCapability::ExecuteBinaryInDistribution)]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         setup_logging()?;

--- a/examples/dist-info/src/lib.rs
+++ b/examples/dist-info/src/lib.rs
@@ -55,7 +55,7 @@ fn setup_logging() -> WinResult<()> {
     Ok(())
 }
 
-#[wsl_plugin_v1(2, 1, 2)]
+#[wsl_plugin_v1(wslplugins_rs::WSLVersionCapability::ExecuteBinaryInDistribution)]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         setup_logging()?;

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -6,9 +6,13 @@ It keeps the same observable behavior as the original sample:
 - it opens `C:\wsl-plugin-demo.txt` when the plugin is loaded
 - it logs VM and distribution lifecycle events
 - it runs `/bin/cat /proc/version` when the VM starts
-- it requires WSL `2.1.3` because it uses distribution registration hooks
+- it handles the same registration lifecycle events as the sample plugin
 
 The remaining differences stem from the framework architecture and idiomatic Rust:
-- `#[wsl_plugin_v1(2, 1, 3)]` generates the entry point and hook registration using the [`wslplugins_rs::wsl_plugin_v1`] macro
+- `#[wsl_plugin_v1(...)]` generates the entry point and hook registration using the [`wslplugins_rs::wsl_plugin_v1`] macro
 - [`wslplugins_rs::plugin::WSLPluginV1`] stores plugin state in a Rust struct instead of global variables
 - `ApiV1::new_command(...).execute()` replaces the manual `ExecuteBinary` and socket handling using the [`wslplugins_rs::api::WSLCommand`] API
+
+New plugins should prefer named `WSLVersionCapability` requirements where available. The book's
+version capabilities chapter lists the capabilities for registration hooks, distribution-scoped
+command execution, and version-gated distribution fields.

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -51,7 +51,7 @@ fn setup_logging() -> WinResult<()> {
 #[derive(Debug)]
 pub(crate) struct Plugin;
 
-#[wsl_plugin_v1(2, 1, 2)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for Plugin {
     fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
         setup_logging()?;


### PR DESCRIPTION
## Summary

- Adds explicit WSL version capability modeling so plugin code can reason about features by capability instead of raw version checks.
- Exposes capability support helpers on `WSLVersion` and lets the proc macro declare one or more required capabilities.

## Changes

- Added `WSLVersion` and `WSLVersionCapability` support APIs, including `WSLVersion::supports` and `WSLVersion::capabilities`.
- Updated plugin registration utilities to select the highest required capability version when creating plugins.
- Extended `#[wsl_plugin_v1(...)]` parsing so required capabilities can be combined with `|`.
- Added macro coverage for capability requirements.

## Components Touched

- [x] Public API
- [x] Proc macro
- [x] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [ ] Documentation
- [ ] Examples
- [ ] CI / release workflow
- [ ] AGENTS.md instructions

## Validation

- [x] `cargo test --workspace --all-features`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo fmt --all -- --check`
- [ ] Relevant manual testing completed

## WSL / Windows Notes

- This affects plugin creation metadata by deriving the required WSL version from declared capabilities.
- No manual Windows plugin loading, signing, registration, or WSL service restart validation was performed.

## Checklist

- [x] Tests added or updated when relevant
- [ ] Documentation updated when relevant
- [ ] Examples updated when relevant
- [x] No unrelated changes included