### PR TITLE
Add wslplugins-rs book

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,5 +37,6 @@
 
 - [ ] Tests added or updated when relevant
 - [ ] Documentation updated when relevant
+- [ ] Book updated as needed for public API changes, or the PR explains why no book update is needed
 - [ ] Examples updated when relevant
 - [ ] No unrelated changes included

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@
 - [ ] `cargo test --workspace --all-features`
 - [ ] `cargo clippy --workspace --all-targets --all-features`
 - [ ] `cargo fmt --all -- --check`
+- [ ] `mdbook build book` when the book is changed
 - [ ] Relevant manual testing completed
 
 ## WSL / Windows Notes

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,9 +23,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build mdBook
-    runs-on: ubuntu-latest
+  check:
+    name: Check mdBook
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,8 +46,24 @@ jobs:
       - name: Build
         run: mdbook build book
 
+  build-pages:
+    name: Build Pages artifact
+    if: github.event_name != 'pull_request'
+    needs: check
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mdBook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+
+      - name: Build
+        run: mdbook build book
+
       - name: Upload artifact
-        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: target/book
@@ -55,7 +71,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     if: github.event_name != 'pull_request'
-    needs: build
+    needs: build-pages
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - main
+      - develop
+      - release/*
     paths:
       - book/**
       - .github/workflows/book.yml
   pull_request:
+    branches:
+      - main
+      - develop
+      - release/*
     paths:
       - book/**
       - .github/workflows/book.yml
@@ -26,13 +32,34 @@ jobs:
   test-snippets:
     name: Test Rust snippets
     runs-on: windows-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: -D warnings
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo Git Index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      - name: Install Rust
+        shell: pwsh
+        run: rustup update stable && rustup default stable
 
       - name: Install mdbook
         run: cargo install mdbook
-      
+
       - name: Build snippet dependencies
         run: cargo build -p wslplugins-rs --features macro
         env:
@@ -43,15 +70,33 @@ jobs:
 
   build:
     name: Build mdBook
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    env:
+      CARGO_TERM_COLOR: always
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Install mdBook
-        uses: taiki-e/install-action@v2
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
         with:
-          tool: mdbook
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo Git Index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      - name: Install Rust
+        shell: pwsh
+        run: rustup update stable && rustup default stable
+
+      - name: Install mdbook
+        run: cargo install mdbook
 
       - name: Build
         run: mdbook build book
@@ -62,15 +107,33 @@ jobs:
     needs:
       - build
       - test-snippets
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    env:
+      CARGO_TERM_COLOR: always
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Install mdBook
-        uses: taiki-e/install-action@v2
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
         with:
-          tool: mdbook
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo Git Index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      - name: Install Rust
+        shell: pwsh
+        run: rustup update stable && rustup default stable
+
+      - name: Install mdbook
+        run: cargo install mdbook
 
       - name: Build
         run: mdbook build book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -30,11 +30,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install mdBook
-        uses: taiki-e/install-action@v2
-        with:
-          tool: mdbook
-
+      - name: Install mdbook
+        run: cargo install mdbook
+      
       - name: Build snippet dependencies
         run: cargo build -p wslplugins-rs --features macro
         env:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,8 +23,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check:
-    name: Check mdBook
+  test-snippets:
+    name: Test Rust snippets
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -43,14 +43,28 @@ jobs:
       - name: Test Rust snippets
         run: mdbook test book -L .tmp/book-doctest-target/debug/deps
 
+  build:
+    name: Build mdBook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mdBook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+
       - name: Build
         run: mdbook build book
 
   build-pages:
     name: Build Pages artifact
     if: github.event_name != 'pull_request'
-    needs: check
-    runs-on: windows-latest
+    needs:
+      - build
+      - test-snippets
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,66 @@
+name: Book
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - book/**
+      - .github/workflows/book.yml
+  pull_request:
+    paths:
+      - book/**
+      - .github/workflows/book.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build mdBook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mdBook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+
+      - name: Build snippet dependencies
+        run: cargo build -p wslplugins-rs --features macro
+        env:
+          CARGO_TARGET_DIR: .tmp/book-doctest-target
+
+      - name: Test Rust snippets
+        run: mdbook test book -L .tmp/book-doctest-target/debug/deps
+
+      - name: Build
+        run: mdbook build book
+
+      - name: Upload artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/book
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Place ordinary Rust tests next to the code or in crate-level `tests/` directorie
 
 ## Documentation Guidelines
 
-The mdBook in `book/` is the user-oriented guide for this library. When changing public APIs, examples, plugin behavior, packaging, validation, or anything users need to understand to build WSL plugins, update the book in the same change. If a change intentionally does not require a book update, make that explicit in the pull request.
+The mdBook in `book/` is the user-oriented guide for this library. When changing the public API, update the book as much as needed so users can understand the new or changed API surface. Also update the book when changing examples, plugin behavior, packaging, validation, or anything users need to understand to build WSL plugins. If a change intentionally does not require a book update, make that explicit in the pull request.
 
 ## Git Flow & Pull Requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ Use Rust 2021 and the repository `rustfmt.toml` settings. Use `snake_case` for c
 
 Place ordinary Rust tests next to the code or in crate-level `tests/` directories. Macro behavior belongs in `crates/wslplugins-macro-tests/tests/`, with UI fixtures under `tests/ui/`. Name tests after behavior, for example `formats_user_distribution_id_as_guid`. Run the full workspace test command before opening a pull request that changes code.
 
+## Documentation Guidelines
+
+The mdBook in `book/` is the user-oriented guide for this library. When changing public APIs, examples, plugin behavior, packaging, validation, or anything users need to understand to build WSL plugins, update the book in the same change. If a change intentionally does not require a book update, make that explicit in the pull request.
+
 ## Git Flow & Pull Requests
 
 Git Flow applies to published library crates: `develop` carries versioned crate work, while `main` remains the stable branch. Create `feature/*` and `fix/*` branches from `develop`, and target their pull requests back to `develop`. Use `release/*` branches for versioned release preparation, final validation, and publishing dry runs before merging to `main` and back to `develop`.
@@ -44,4 +48,3 @@ Recent commits use short imperative or descriptive subjects, often with PR numbe
 ## Security & Configuration Tips
 
 Do not commit private certificates, keys, signed DLLs, or machine-specific registry paths. Treat `sign-plugin.ps1 -Trust`, registry edits, and WSL service restarts as host-affecting operations.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,8 @@ Good pull request descriptions usually include:
 - Test results for the checks that were run.
 - Windows validation notes when the change was actually tested with WSL.
 
+When a pull request changes the public API, update the mdBook in `book/` as much as needed so users can understand the new or changed API surface. If no book update is needed for a public API change, explain why in the pull request.
+
 Keep commits focused. Recent commit subjects use short imperative or descriptive wording, for example:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/wslplugins-rs?logo=rust)](https://crates.io/crates/wslplugins-rs)
 [![Docs.rs](https://img.shields.io/badge/docs.rs-wslplugins--rs-blue?logo=docs.rs)](https://docs.rs/wslplugins-rs)
+[![Book](https://img.shields.io/badge/book-mdBook-blue?logo=mdbook)](https://mveril.github.io/wslplugins-rs/)
 [![Build Status](https://github.com/mveril/wslplugins-rs/actions/workflows/rust.yml/badge.svg?logo=github)](https://github.com/mveril/wslplugins-rs/actions)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE-APACHE)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
@@ -46,6 +47,11 @@ The workspace is organized around a small public API surface and separate macro 
 - `wslplugins-macro-tests`: compile-time tests for macro-generated plugin code.
 
 This split keeps plugin authors focused on `wslplugins-rs`, while the macro parsing and generated WSL entry-point wiring stay isolated in internal crates.
+
+## Documentation
+
+- [The wslplugins-rs Book](https://mveril.github.io/wslplugins-rs/) explains the development flow from first plugin to packaging.
+- [docs.rs](https://docs.rs/wslplugins-rs) contains the generated API reference.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ This split keeps plugin authors focused on `wslplugins-rs`, while the macro pars
 - [The wslplugins-rs Book](https://mveril.github.io/wslplugins-rs/) explains the development flow from first plugin to packaging.
 - [docs.rs](https://docs.rs/wslplugins-rs) contains the generated API reference.
 
+To build the book locally, install [mdBook](https://rust-lang.github.io/mdBook/guide/installation.html)
+with Cargo and run:
+
+```powershell
+cargo install mdbook
+mdbook build book
+```
+
 ## Quick Start
 
 Add the crate with the `macro` feature:

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,13 @@
+[book]
+title = "The wslplugins-rs Book"
+authors = ["Mickaël Véril"]
+language = "en"
+src = "src"
+
+[build]
+build-dir = "../target/book"
+
+[output.html]
+git-repository-url = "https://github.com/mveril/wslplugins-rs"
+edit-url-template = "https://github.com/mveril/wslplugins-rs/edit/main/book/{path}"
+site-url = "/wslplugins-rs/"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,8 @@
 - [End-to-End Quickstart](./quickstart.md)
 - [Your First Plugin](./first-plugin.md)
 - [WSL Plugin Model](./wsl-plugin-model.md)
+- [Error Handling](./error-handling.md)
+- [Command Execution](./command-execution.md)
 - [FFI and Safety](./ffi-and-safety.md)
 - [Testing](./testing.md)
 - [Packaging and Deployment](./packaging.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,8 +5,10 @@
 # User Guide
 
 - [Getting Started](./getting-started.md)
+- [End-to-End Quickstart](./quickstart.md)
 - [Your First Plugin](./first-plugin.md)
 - [WSL Plugin Model](./wsl-plugin-model.md)
 - [FFI and Safety](./ffi-and-safety.md)
 - [Testing](./testing.md)
 - [Packaging and Deployment](./packaging.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+- [Introduction](./introduction.md)
+
+# User Guide
+
+- [Getting Started](./getting-started.md)
+- [Your First Plugin](./first-plugin.md)
+- [WSL Plugin Model](./wsl-plugin-model.md)
+- [FFI and Safety](./ffi-and-safety.md)
+- [Testing](./testing.md)
+- [Packaging and Deployment](./packaging.md)

--- a/book/src/command-execution.md
+++ b/book/src/command-execution.md
@@ -1,0 +1,44 @@
+# Command Execution
+
+`ApiV1::new_command` builds a Linux command to run in a WSL session. The program path and arguments
+must be valid for the target Linux environment:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_FAIL: HRESULT = HRESULT(0x80004005u32 as i32);
+
+fn read_kernel_version(
+    context: &WSLContext,
+    session: &WSLSessionInformation,
+) -> PluginResult<String> {
+    let mut stream = context
+        .api
+        .new_command(session, "/bin/cat")
+        .with_arg("/proc/version")
+        .execute()?;
+
+    let mut kernel_version = String::new();
+    std::io::Read::read_to_string(&mut stream, &mut kernel_version).map_err(|error| {
+        PluginError::with_message(E_FAIL, OsString::from(error.to_string()))
+    })?;
+
+    Ok(kernel_version)
+}
+```
+
+The returned stream is connected to stdin and stdout. Drop it when no more interaction is needed.
+
+By default, `WSLCommand` targets the system/root namespace through the WSL API `ExecuteBinary`. This
+namespace is not the same as a user distribution. Microsoft documents it as a minimal Mariner-based
+root filesystem backed by writable `tmpfs`, so changes made there disappear when the WSL2 VM shuts
+down.
+
+Use a user-distribution target when the command must run inside a distribution rather than the root
+namespace. That path uses `ExecuteBinaryInDistribution`, which requires API version `2.1.2` or newer.
+
+The returned `TcpStream` is connected to the command's stdin and stdout. It does not carry stderr;
+WSL sends stderr output to Linux `dmesg`.

--- a/book/src/error-handling.md
+++ b/book/src/error-handling.md
@@ -1,0 +1,61 @@
+# Error Handling
+
+WSL plugins run inside the WSL service process, so failures should be explicit errors instead of
+process-level failures. Return errors instead of panicking:
+
+- use `WinResult<T>` for Windows API style errors;
+- use `PluginResult<T>` for plugin hook errors;
+- map I/O errors into Windows errors where required by the hook signature;
+- avoid `panic!`, `unwrap`, and `expect` in plugin code.
+
+Panics are a poor fit for WSL plugins because the plugin is loaded inside a WSL service process, not
+inside a short-lived CLI that only affects its own execution. A panic in a hook can unwind through an
+FFI boundary, abort the process, poison shared state, or leave WSL with only a generic failure code.
+The host is also allowed to call hooks during lifecycle operations such as VM startup, distribution
+registration, or shutdown; failing predictably is more useful than terminating the service path.
+
+Avoiding `unwrap` and `expect` is part of the same rule. A missing field, inaccessible file, invalid
+distribution name, or failed command execution should become an explicit error that WSL can report
+or handle. It should not become an accidental process failure.
+
+## Plugin Errors and Windows Errors
+
+`wslplugins-rs` exposes two result styles because WSL has two different error channels:
+
+- `WinResult<T>` returns a normal Windows `HRESULT` to the host.
+- `PluginResult<T>` returns `PluginError`, which contains an `HRESULT` and an optional message.
+
+Use `WinResult<T>` when the hook signature is purely Windows-style or when only an error code is
+expected. Use `PluginResult<T>` where the framework hook supports a plugin-level diagnostic message.
+
+When a `PluginError` has a message, the framework sends that message to WSL through the plugin API
+before converting the error back into a Windows error code. That gives WSL a human-readable plugin
+diagnostic instead of only an `HRESULT`. In practice, this is useful for policy-style failures where
+the user should see why an operation was denied:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_ACCESSDENIED: HRESULT = HRESULT(0x80070005u32 as i32);
+
+fn reject_distribution(name: &str) -> PluginResult<()> {
+    Err(PluginError::with_message(
+        E_ACCESSDENIED,
+        OsString::from(format!(
+            "Distribution '{name}' is blocked by local policy"
+        )),
+    ))
+}
+```
+
+If you convert everything to `windows_core::Error` too early, WSL still receives the failure code,
+but it can lose the plugin-specific explanation. Prefer `PluginResult` for hooks where the message
+is part of the user experience.
+
+The raw `PluginError` API is intended for synchronous use while WSL is processing VM or distribution
+creation. In practice, use `PluginResult` from `on_vm_started` and `on_distribution_started` when a
+message should be shown to the user. Do not store a delayed error message and try to report it after
+the hook has returned.

--- a/book/src/ffi-and-safety.md
+++ b/book/src/ffi-and-safety.md
@@ -1,0 +1,162 @@
+# FFI and Safety
+
+WSL plugins run inside the WSL service process. A crash, panic across an FFI boundary, invalid
+pointer, or blocking hook can affect the host service. Treat plugin code like systems code even when
+using safe Rust wrappers.
+
+## Error Handling
+
+Return errors instead of panicking:
+
+- use `WinResult<T>` for Windows API style errors;
+- use `PluginResult<T>` for plugin hook errors;
+- map I/O errors into Windows errors where required by the hook signature;
+- avoid `panic!`, `unwrap`, and `expect` in plugin code.
+
+Panics are a poor fit for WSL plugins because the plugin is loaded inside a WSL service process, not
+inside a short-lived CLI that only affects its own execution. A panic in a hook can unwind through an
+FFI boundary, abort the process, poison shared state, or leave WSL with only a generic failure code.
+The host is also allowed to call hooks during lifecycle operations such as VM startup, distribution
+registration, or shutdown; failing predictably is more useful than terminating the service path.
+
+Avoiding `unwrap` and `expect` is part of the same rule. A missing field, inaccessible file, invalid
+distribution name, or failed command execution should become an explicit error that WSL can report
+or handle. It should not become an accidental process failure.
+
+## Plugin Errors and Windows Errors
+
+`wslplugins-rs` exposes two result styles because WSL has two different error channels:
+
+- `WinResult<T>` returns a normal Windows `HRESULT` to the host.
+- `PluginResult<T>` returns `PluginError`, which contains an `HRESULT` and an optional message.
+
+Use `WinResult<T>` when the hook signature is purely Windows-style or when only an error code is
+expected. Use `PluginResult<T>` where the framework hook supports a plugin-level diagnostic message.
+
+When a `PluginError` has a message, the framework sends that message to WSL through the plugin API
+before converting the error back into a Windows error code. That gives WSL a human-readable plugin
+diagnostic instead of only an `HRESULT`. In practice, this is useful for policy-style failures where
+the user should see why an operation was denied:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_ACCESSDENIED: HRESULT = HRESULT(0x80070005u32 as i32);
+
+fn reject_distribution(name: &str) -> PluginResult<()> {
+    Err(PluginError::with_message(
+        E_ACCESSDENIED,
+        OsString::from(format!(
+            "Distribution '{name}' is blocked by local policy"
+        )),
+    ))
+}
+```
+
+If you convert everything to `windows_core::Error` too early, WSL still receives the failure code,
+but it can lose the plugin-specific explanation. Prefer `PluginResult` for hooks where the message
+is part of the user experience.
+
+The raw `PluginError` API is intended for synchronous use while WSL is processing VM or distribution
+creation. In practice, use `PluginResult` from `on_vm_started` and `on_distribution_started` when a
+message should be shown to the user. Do not store a delayed error message and try to report it after
+the hook has returned.
+
+## Unsafe Code
+
+Most plugin code should not need raw FFI access. When unsafe code is necessary:
+
+- keep unsafe blocks as small as possible;
+- document each block with a `SAFETY:` comment;
+- validate pointer lifetimes and ownership before wrapping raw values;
+- avoid storing borrowed FFI data beyond the lifetime guaranteed by WSL.
+
+The `wslplugins-rs` crate centralizes raw API handling so plugin authors can usually work with typed
+Rust values instead.
+
+## Hook Behavior
+
+Hooks are synchronous notifications. Keep them predictable:
+
+- do the minimum required work in the hook;
+- avoid unbounded waits;
+- avoid holding locks while calling into WSL APIs;
+- make logging best-effort and failure-aware;
+- assume hooks may be called multiple times for lifecycle retries.
+
+If a plugin needs heavier work, prefer moving it to a controlled background path with clear
+shutdown behavior.
+
+Microsoft's WSL plugin documentation calls out three operational consequences of this model:
+
+- WSL waits for hook callbacks before continuing the lifecycle operation.
+- Most plugin errors are fatal to the VM or distribution startup path.
+- Plugin code runs in the WSL service process, so a plugin crash can crash the service.
+
+That is why the framework examples keep hooks small and use typed errors instead of process-level
+failure mechanisms.
+
+## Command Execution
+
+`ApiV1::new_command` builds a Linux command to run in a WSL session. The program path and arguments
+must be valid for the target Linux environment:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_FAIL: HRESULT = HRESULT(0x80004005u32 as i32);
+
+fn read_kernel_version(
+    context: &WSLContext,
+    session: &WSLSessionInformation,
+) -> PluginResult<String> {
+    let mut stream = context
+        .api
+        .new_command(session, "/bin/cat")
+        .with_arg("/proc/version")
+        .execute()?;
+
+    let mut kernel_version = String::new();
+    std::io::Read::read_to_string(&mut stream, &mut kernel_version).map_err(|error| {
+        PluginError::with_message(E_FAIL, OsString::from(error.to_string()))
+    })?;
+
+    Ok(kernel_version)
+}
+```
+
+The returned stream is connected to stdin and stdout. Drop it when no more interaction is needed.
+
+By default, `WSLCommand` targets the system/root namespace through the WSL API `ExecuteBinary`. This
+namespace is not the same as a user distribution. Microsoft documents it as a minimal Mariner-based
+root filesystem backed by writable `tmpfs`, so changes made there disappear when the WSL2 VM shuts
+down.
+
+Use a user-distribution target when the command must run inside a distribution rather than the root
+namespace. That path uses `ExecuteBinaryInDistribution`, which requires API version `2.1.2` or newer.
+
+The WSL Plugin API connects the returned socket to stdin and stdout. Stderr is sent to Linux
+`dmesg`, so command failures should be designed with that in mind: return explicit hook errors for
+user-facing failures, and reserve stderr for diagnostics that can be inspected from the Linux side.
+
+## Advanced FFI Notes
+
+The `sys` feature re-exports the raw `wslpluginapi-sys` bindings for cases where the safe wrapper
+does not yet expose a field or function. Prefer the safe wrapper first. If raw access is necessary,
+keep these header-level rules in mind:
+
+- hook input pointers are valid only during the callback;
+- string pointers from WSL may be null where the header allows it, such as `PackageFamilyName`;
+- `ExecuteBinary` argument arrays are null-terminated at the ABI boundary;
+- `WSLDistributionInformation::InitPid` was introduced in API version `2.0.5`;
+- `Flavor` and `Version` exist in the current header; `wslplugins-rs` exposes them through
+  `flavor()` and `version()` and currently requires API version `2.4.4` before reading them.
+
+These details are useful when debugging ABI mismatches, but ordinary plugin logic should stay on the
+typed Rust side.

--- a/book/src/ffi-and-safety.md
+++ b/book/src/ffi-and-safety.md
@@ -4,66 +4,8 @@ WSL plugins run inside the WSL service process. A crash, panic across an FFI bou
 pointer, or blocking hook can affect the host service. Treat plugin code like systems code even when
 using safe Rust wrappers.
 
-## Error Handling
-
-Return errors instead of panicking:
-
-- use `WinResult<T>` for Windows API style errors;
-- use `PluginResult<T>` for plugin hook errors;
-- map I/O errors into Windows errors where required by the hook signature;
-- avoid `panic!`, `unwrap`, and `expect` in plugin code.
-
-Panics are a poor fit for WSL plugins because the plugin is loaded inside a WSL service process, not
-inside a short-lived CLI that only affects its own execution. A panic in a hook can unwind through an
-FFI boundary, abort the process, poison shared state, or leave WSL with only a generic failure code.
-The host is also allowed to call hooks during lifecycle operations such as VM startup, distribution
-registration, or shutdown; failing predictably is more useful than terminating the service path.
-
-Avoiding `unwrap` and `expect` is part of the same rule. A missing field, inaccessible file, invalid
-distribution name, or failed command execution should become an explicit error that WSL can report
-or handle. It should not become an accidental process failure.
-
-## Plugin Errors and Windows Errors
-
-`wslplugins-rs` exposes two result styles because WSL has two different error channels:
-
-- `WinResult<T>` returns a normal Windows `HRESULT` to the host.
-- `PluginResult<T>` returns `PluginError`, which contains an `HRESULT` and an optional message.
-
-Use `WinResult<T>` when the hook signature is purely Windows-style or when only an error code is
-expected. Use `PluginResult<T>` where the framework hook supports a plugin-level diagnostic message.
-
-When a `PluginError` has a message, the framework sends that message to WSL through the plugin API
-before converting the error back into a Windows error code. That gives WSL a human-readable plugin
-diagnostic instead of only an `HRESULT`. In practice, this is useful for policy-style failures where
-the user should see why an operation was denied:
-
-```rust
-# extern crate wslplugins_rs;
-use std::ffi::OsString;
-use wslplugins_rs::prelude::*;
-use wslplugins_rs::windows_core::HRESULT;
-
-const E_ACCESSDENIED: HRESULT = HRESULT(0x80070005u32 as i32);
-
-fn reject_distribution(name: &str) -> PluginResult<()> {
-    Err(PluginError::with_message(
-        E_ACCESSDENIED,
-        OsString::from(format!(
-            "Distribution '{name}' is blocked by local policy"
-        )),
-    ))
-}
-```
-
-If you convert everything to `windows_core::Error` too early, WSL still receives the failure code,
-but it can lose the plugin-specific explanation. Prefer `PluginResult` for hooks where the message
-is part of the user experience.
-
-The raw `PluginError` API is intended for synchronous use while WSL is processing VM or distribution
-creation. In practice, use `PluginResult` from `on_vm_started` and `on_distribution_started` when a
-message should be shown to the user. Do not store a delayed error message and try to report it after
-the hook has returned.
+Because hooks cross an FFI boundary, plugin code should return typed errors instead of panicking.
+See [Error Handling](./error-handling.md) for the `WinResult` and `PluginResult` conventions.
 
 ## Unsafe Code
 
@@ -98,52 +40,6 @@ Microsoft's WSL plugin documentation calls out three operational consequences of
 
 That is why the framework examples keep hooks small and use typed errors instead of process-level
 failure mechanisms.
-
-## Command Execution
-
-`ApiV1::new_command` builds a Linux command to run in a WSL session. The program path and arguments
-must be valid for the target Linux environment:
-
-```rust
-# extern crate wslplugins_rs;
-use std::ffi::OsString;
-use wslplugins_rs::prelude::*;
-use wslplugins_rs::windows_core::HRESULT;
-
-const E_FAIL: HRESULT = HRESULT(0x80004005u32 as i32);
-
-fn read_kernel_version(
-    context: &WSLContext,
-    session: &WSLSessionInformation,
-) -> PluginResult<String> {
-    let mut stream = context
-        .api
-        .new_command(session, "/bin/cat")
-        .with_arg("/proc/version")
-        .execute()?;
-
-    let mut kernel_version = String::new();
-    std::io::Read::read_to_string(&mut stream, &mut kernel_version).map_err(|error| {
-        PluginError::with_message(E_FAIL, OsString::from(error.to_string()))
-    })?;
-
-    Ok(kernel_version)
-}
-```
-
-The returned stream is connected to stdin and stdout. Drop it when no more interaction is needed.
-
-By default, `WSLCommand` targets the system/root namespace through the WSL API `ExecuteBinary`. This
-namespace is not the same as a user distribution. Microsoft documents it as a minimal Mariner-based
-root filesystem backed by writable `tmpfs`, so changes made there disappear when the WSL2 VM shuts
-down.
-
-Use a user-distribution target when the command must run inside a distribution rather than the root
-namespace. That path uses `ExecuteBinaryInDistribution`, which requires API version `2.1.2` or newer.
-
-The WSL Plugin API connects the returned socket to stdin and stdout. Stderr is sent to Linux
-`dmesg`, so command failures should be designed with that in mind: return explicit hook errors for
-user-facing failures, and reserve stderr for diagnostics that can be inspected from the Linux side.
 
 ## Advanced FFI Notes
 

--- a/book/src/first-plugin.md
+++ b/book/src/first-plugin.md
@@ -91,3 +91,6 @@ cargo build --release
 ```
 
 After that, sign and register the DLL as described in the packaging chapter.
+
+Next: read [WSL Plugin Model](./wsl-plugin-model.md) for the host model and versioning rules, or
+jump to [Packaging and Deployment](./packaging.md) when you are ready to load the DLL into WSL.

--- a/book/src/first-plugin.md
+++ b/book/src/first-plugin.md
@@ -1,0 +1,93 @@
+# Your First Plugin
+
+The minimal shape of a plugin is a Rust `cdylib` crate containing a type plus an implementation of
+`WSLPluginV1`.
+The `#[wsl_plugin_v1(...)]` macro generates the exported functions and hook wiring expected by WSL.
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct MyPlugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 0, 5)]
+impl WSLPluginV1 for MyPlugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+The version in `#[wsl_plugin_v1(major, minor, revision)]` declares the WSL plugin API version
+required by the plugin. The revision component is optional and defaults to `0`. Use the lowest
+version that provides the hooks and API calls your plugin needs.
+
+The `context` gives access to the framework API wrapper. Store it if the plugin needs to call WSL
+APIs later from hook methods.
+
+## Add Hooks
+
+Hooks are regular trait methods. Override only the lifecycle events the plugin needs:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_FAIL: HRESULT = HRESULT(0x80004005u32 as i32);
+
+pub(crate) struct MyPlugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for MyPlugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+
+    fn on_vm_started(
+        &self,
+        session: &WSLSessionInformation,
+        user_settings: &WSLVmCreationSettings,
+    ) -> PluginResult<()> {
+        let mut stream = self
+            .context
+            .api
+            .new_command(session, "/bin/cat")
+            .with_arg("/proc/version")
+            .execute()?;
+
+        let mut kernel_version = String::new();
+        std::io::Read::read_to_string(&mut stream, &mut kernel_version).map_err(|error| {
+            PluginError::with_message(E_FAIL, OsString::from(error.to_string()))
+        })?;
+        Ok(())
+    }
+}
+```
+
+Command paths are Linux paths such as `/bin/cat`. `execute()` returns a `TcpStream` connected to the
+process stdin and stdout; stderr is forwarded to Linux `dmesg`.
+
+## Start from an Example
+
+If you want a complete working reference, start with the `minimal` example from the repository. It
+demonstrates:
+
+- creating plugin state in `try_new`;
+- logging VM and distribution lifecycle events;
+- running `/bin/cat /proc/version` when the VM starts;
+- using `#[wsl_plugin_v1(2, 1, 3)]` because it handles distribution registration hooks. Those
+  hooks are available starting with API version `2.1.2`; the example currently targets `2.1.3`.
+
+In your own plugin crate, the equivalent release build is:
+
+```powershell
+cargo build --release
+```
+
+After that, sign and register the DLL as described in the packaging chapter.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -3,6 +3,9 @@
 This chapter assumes you are creating a plugin crate outside this repository and want to consume
 `wslplugins-rs` as a dependency.
 
+If you want the shortest copy-and-run path first, use the
+[End-to-End Quickstart](./quickstart.md), then return here for the background details.
+
 ## Prerequisites
 
 Install these tools on Windows:
@@ -10,9 +13,14 @@ Install these tools on Windows:
 - Rust stable and Cargo.
 - PowerShell.
 - `SignTool.exe` from the Windows SDK.
+- WSL installed and able to run at least one distribution.
+- A Windows environment that can build native MSVC Rust targets.
 
 `SignTool.exe` is usually easiest to access from a Visual Studio Developer Command Prompt or from a
 shell where the Windows SDK tools are on `PATH`.
+
+Packaging and host validation also require administrator access because local testing can touch the
+machine certificate store, the `HKLM` registry hive, and the WSL service.
 
 ## Create a Plugin Crate
 
@@ -97,3 +105,6 @@ The repository examples show complete plugins for common scenarios:
 - `unpackaged-distro-blacklist-policy`: a policy-style plugin.
 
 Use them as references for plugin behavior, not as required workspace structure.
+
+Next: follow the [End-to-End Quickstart](./quickstart.md) for a complete deployment loop, or read
+[Your First Plugin](./first-plugin.md) to add hook behavior.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -10,10 +10,12 @@ If you want the shortest copy-and-run path first, use the
 
 Install these tools on Windows:
 
-- Rust stable and Cargo.
+- [Rust stable and Cargo](https://www.rust-lang.org/tools/install).
 - PowerShell.
-- `SignTool.exe` from the Windows SDK.
-- WSL installed and able to run at least one distribution.
+- [`SignTool.exe`](https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool) from the
+  Windows SDK.
+- [WSL installed](https://learn.microsoft.com/en-us/windows/wsl/install) and able to run at least
+  one distribution.
 - A Windows environment that can build native MSVC Rust targets.
 
 `SignTool.exe` is usually easiest to access from a Visual Studio Developer Command Prompt or from a

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,0 +1,99 @@
+# Getting Started
+
+This chapter assumes you are creating a plugin crate outside this repository and want to consume
+`wslplugins-rs` as a dependency.
+
+## Prerequisites
+
+Install these tools on Windows:
+
+- Rust stable and Cargo.
+- PowerShell.
+- `SignTool.exe` from the Windows SDK.
+
+`SignTool.exe` is usually easiest to access from a Visual Studio Developer Command Prompt or from a
+shell where the Windows SDK tools are on `PATH`.
+
+## Create a Plugin Crate
+
+Create a Rust library crate and configure it to produce a DLL:
+
+```powershell
+cargo new my-wsl-plugin --lib
+cd my-wsl-plugin
+```
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+The crate can contain normal Rust modules and dependencies. The important requirement is that the
+final artifact is a native Windows DLL that WSL can load.
+
+## Add the Framework
+
+Most plugins should enable the `macro` feature so the crate generates the required WSL exports:
+
+```toml
+[dependencies]
+wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+```
+
+Import the prelude in your plugin code:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+```
+
+## Implement the Plugin
+
+A minimal plugin is a type plus a `WSLPluginV1` implementation:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct Plugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 0, 5)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+Add hook methods only for the events your plugin handles. The default implementation for each hook
+does nothing and returns success.
+
+## Validate During Development
+
+Run ordinary Rust checks while developing:
+
+```powershell
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt -- --check
+```
+
+When you are ready to load the plugin into WSL, build a release DLL:
+
+```powershell
+cargo build --release
+```
+
+The DLL is written under `target\release\` using your crate name.
+
+## Use the Examples
+
+The repository examples show complete plugins for common scenarios:
+
+- `minimal`: lifecycle hooks and command execution inside a WSL session.
+- `dist-info`: distribution metadata access.
+- `unpackaged-distro-blacklist-policy`: a policy-style plugin.
+
+Use them as references for plugin behavior, not as required workspace structure.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,0 +1,37 @@
+# Introduction
+
+`wslplugins-rs` is a Rust framework for building DLL plugins loaded by Windows Subsystem for Linux.
+It wraps the raw WSL plugin API with Rust types and provides a procedural macro that generates the
+exported entry points and hook registration code expected by WSL.
+
+Use it when your plugin needs to observe WSL lifecycle events, inspect distribution metadata, or run
+commands inside a WSL session from plugin code.
+
+This book is written for plugin authors using the library in their own crate. It focuses on the path
+from an empty Rust plugin project to a signed and registered DLL on Windows. For item-by-item API
+reference, use the generated Rust documentation on docs.rs.
+
+## Design Goals
+
+The framework keeps the plugin authoring model small:
+
+- implement `WSLPluginV1` for a Rust type that owns the plugin state;
+- annotate the implementation with `#[wsl_plugin_v1(...)]`;
+- use typed wrappers for WSL sessions, distributions, versions, and command execution;
+- return errors instead of panicking inside the WSL service process.
+
+WSL loads plugins into a host service process. Reliability and conservative error handling matter
+more than convenience shortcuts.
+
+## What You Build
+
+A plugin built with `wslplugins-rs` is a Rust library crate compiled as a Windows DLL:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+The DLL is then signed, registered under the WSL plugins registry key, and loaded by the WSL service.
+The examples in the repository are useful starting points, but the same model applies to any plugin
+crate that depends on `wslplugins-rs`.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -21,7 +21,8 @@ The framework keeps the plugin authoring model small:
 - return errors instead of panicking inside the WSL service process.
 
 WSL loads plugins into a host service process. Reliability and conservative error handling matter
-more than convenience shortcuts.
+more than convenience shortcuts. The [Error Handling](./error-handling.md) chapter explains how to
+turn plugin failures into `WinResult` or `PluginResult` values.
 
 ## What You Build
 

--- a/book/src/packaging.md
+++ b/book/src/packaging.md
@@ -1,0 +1,115 @@
+# Packaging and Deployment
+
+WSL loads plugin DLLs from Windows. A development deployment usually has four steps:
+
+1. Build the plugin DLL.
+2. Sign the DLL.
+3. Register the DLL path in the WSL plugins registry key.
+4. Restart the WSL service and trigger plugin loading.
+
+The underlying Microsoft package for the native API is `Microsoft.WSL.PluginApi` on NuGet. Version
+`2.4.4` is the current package version checked while writing this page, and it contains the
+`WslPluginApi.h` header used to define the native ABI. Rust users normally consume that ABI through
+`wslplugins-rs` and `wslpluginapi-sys`; you do not need to add the NuGet package to a Rust plugin
+crate unless you are comparing against the C header or writing C/C++ interop code.
+
+## Build a DLL
+
+Build your plugin in release mode when you are ready to deploy it locally:
+
+```powershell
+cargo build --release
+```
+
+The resulting DLL is written to `target\release\<crate-name>.dll`.
+
+## Sign the DLL
+
+WSL requires a signed DLL. In a real deployment, sign with the certificate and process used for your
+environment. During local development, you can use a test certificate and `SignTool.exe`.
+
+The repository includes `sign-plugin.ps1` as a development helper. From an elevated PowerShell
+session in a checkout of this repository:
+
+```powershell
+.\sign-plugin.ps1 -PluginPath C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll
+```
+
+To also trust the generated certificate locally:
+
+```powershell
+.\sign-plugin.ps1 -PluginPath C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll -Trust
+```
+
+The `-Trust` option imports the generated certificate into the local machine trusted root store.
+Do not commit generated certificates, private keys, or signed DLLs.
+
+If WSL rejects a locally signed plugin with `TRUST_E_NOSIGNATURE`, Microsoft documentation may
+require Windows test signing on the test machine:
+
+```powershell
+Bcdedit.exe -set TESTSIGNING ON
+```
+
+A reboot may be required after changing test-signing mode.
+
+If `Bcdedit.exe -set TESTSIGNING ON` fails because the value is protected by Secure Boot policy,
+Microsoft's WSL plugin documentation recommends disabling Secure Boot from firmware settings before
+trying again. Consider the security impact before doing that on a daily-use machine.
+
+## Register the Plugin
+
+Register the signed DLL under the WSL plugins registry key:
+
+```cmd
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" /v my-wsl-plugin /d "C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll" /t REG_SZ
+```
+
+Use a value name and DLL path that match the plugin you are testing.
+
+To unregister the plugin after testing, remove the registry value and restart WSL again:
+
+```powershell
+Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" -Name "my-wsl-plugin" -Force
+Stop-Service -Name "wslservice" -Force
+```
+
+## Reload WSL
+
+Restart the WSL service, then run a WSL command:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+wsl.exe echo "test"
+```
+
+After loading the plugin, verify:
+
+- the DLL path in the registry;
+- the signature status;
+- the expected plugin logs or side effects;
+- Windows validation notes relevant to the change.
+
+Common WSL plugin load failures include:
+
+- `Wsl/Service/CreateInstance/CreateVm/Plugin/ERROR_MOD_NOT_FOUND`: WSL could not load the DLL.
+  Check the registered path and any native dependencies.
+- `Wsl/Service/CreateInstance/CreateVm/Plugin/TRUST_E_NOSIGNATURE`: the DLL is unsigned or the
+  signing certificate is not trusted by the machine.
+- `Wsl/Service/CreateInstance/CreateVm/Plugin/*`: the plugin returned an error from the entry point
+  or `OnVMStarted`.
+- `Wsl/Service/CreateInstance/Plugin/*`: the plugin returned an error from
+  `OnDistributionStarted`.
+
+Because plugins run in the WSL service process, treat host validation as a machine-affecting test:
+keep a note of the registry value you added, the certificate you trusted, and the service restart
+commands you ran.
+
+## Sources
+
+- Microsoft WSL plugin documentation:
+  <https://learn.microsoft.com/en-us/windows/wsl/wsl-plugins>
+- Microsoft WSL Plugin API NuGet package:
+  <https://www.nuget.org/packages/Microsoft.WSL.PluginApi>
+- Microsoft WSL plugin sample:
+  <https://github.com/microsoft/wsl-plugin-sample>

--- a/book/src/packaging.md
+++ b/book/src/packaging.md
@@ -8,10 +8,11 @@ WSL loads plugin DLLs from Windows. A development deployment usually has four st
 4. Restart the WSL service and trigger plugin loading.
 
 The underlying Microsoft package for the native API is `Microsoft.WSL.PluginApi` on NuGet. Version
-`2.4.4` is the current package version checked while writing this page, and it contains the
-`WslPluginApi.h` header used to define the native ABI. Rust users normally consume that ABI through
-`wslplugins-rs` and `wslpluginapi-sys`; you do not need to add the NuGet package to a Rust plugin
-crate unless you are comparing against the C header or writing C/C++ interop code.
+`2.4.4` was the current package version checked on 2026-05-27, and it contains the `WslPluginApi.h`
+header used to define the native ABI. Check NuGet for newer versions when updating bindings or
+comparing against the C header. Rust users normally consume that ABI through `wslplugins-rs` and
+`wslpluginapi-sys`; you do not need to add the NuGet package to a Rust plugin crate unless you are
+comparing against the C header or writing C/C++ interop code.
 
 ## Build a DLL
 
@@ -61,8 +62,15 @@ trying again. Consider the security impact before doing that on a daily-use mach
 
 Register the signed DLL under the WSL plugins registry key:
 
-```cmd
-reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" /v my-wsl-plugin /d "C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll" /t REG_SZ
+```powershell
+$PluginName = "my-wsl-plugin"
+$DllPath = "C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll"
+
+Set-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Value $DllPath `
+    -Force
 ```
 
 Use a value name and DLL path that match the plugin you are testing.
@@ -70,7 +78,11 @@ Use a value name and DLL path that match the plugin you are testing.
 To unregister the plugin after testing, remove the registry value and restart WSL again:
 
 ```powershell
-Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" -Name "my-wsl-plugin" -Force
+Remove-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Force
+
 Stop-Service -Name "wslservice" -Force
 ```
 
@@ -104,6 +116,8 @@ Common WSL plugin load failures include:
 Because plugins run in the WSL service process, treat host validation as a machine-affecting test:
 keep a note of the registry value you added, the certificate you trusted, and the service restart
 commands you ran.
+
+For symptom-by-symptom checks, see [Troubleshooting](./troubleshooting.md).
 
 ## Sources
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -1,0 +1,131 @@
+# End-to-End Quickstart
+
+This chapter shows the shortest complete path from a new Rust crate to a WSL plugin DLL that is
+signed, registered, loaded, tested, and removed again.
+
+Run the deployment commands from an elevated PowerShell session because signing trust, registry
+registration, and WSL service restarts affect the host machine.
+
+## Create the Crate
+
+```powershell
+cargo new my-wsl-plugin --lib
+cd my-wsl-plugin
+```
+
+Configure the crate as a Windows DLL and add the framework dependency:
+
+```toml
+[package]
+name = "my-wsl-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+```
+
+Use this minimal `src/lib.rs`:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct Plugin {
+    _context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 0, 5)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { _context: context })
+    }
+}
+```
+
+Run normal Rust validation first:
+
+```powershell
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt -- --check
+```
+
+Then build the DLL:
+
+```powershell
+cargo build --release
+```
+
+The DLL path uses underscores even when the crate name uses hyphens:
+
+```text
+target\release\my_wsl_plugin.dll
+```
+
+## Sign and Register
+
+The repository contains a development signing helper. Set variables for the plugin you are testing:
+
+```powershell
+$PluginName = "my-wsl-plugin"
+$DllPath = "C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll"
+$RepoPath = "C:\path\to\wslplugins-rs"
+```
+
+Sign the DLL:
+
+```powershell
+& "$RepoPath\sign-plugin.ps1" -PluginPath $DllPath
+```
+
+For local development, you may also trust the generated certificate on the test machine:
+
+```powershell
+& "$RepoPath\sign-plugin.ps1" -PluginPath $DllPath -Trust
+```
+
+Register the signed DLL:
+
+```powershell
+Set-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Value $DllPath `
+    -Force
+```
+
+Restart WSL and trigger plugin loading:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+wsl.exe echo "plugin load test"
+```
+
+## Verify and Clean Up
+
+Check that the registry value points to the DLL you built:
+
+```powershell
+Get-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName
+```
+
+If WSL reports a plugin load error, use the troubleshooting chapter before changing code.
+
+When finished testing, unregister the plugin and restart WSL:
+
+```powershell
+Remove-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Force
+
+Stop-Service -Name "wslservice" -Force
+```
+
+Next: read [Your First Plugin](./first-plugin.md) to add hooks and behavior.

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -1,0 +1,47 @@
+# Testing
+
+Testing a WSL plugin happens at two levels: ordinary Rust validation for your crate and host
+validation on Windows after the DLL is signed and registered.
+
+## Rust Validation
+
+Run normal Rust checks while developing your plugin:
+
+```powershell
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt -- --check
+```
+
+Unit tests are useful for your own parsing, policy, configuration, and decision logic. Keep direct
+WSL service behavior behind small boundaries so most of the plugin can be tested without loading a
+DLL into the host service.
+
+## Hook-Oriented Tests
+
+Where possible, separate hook code from business logic:
+
+```rust
+fn should_block_distribution(name: &str) -> bool {
+    name.eq_ignore_ascii_case("blocked")
+}
+```
+
+Then call that logic from `on_distribution_registered`, `on_vm_started`, or whichever hook applies.
+This keeps hook implementations small and makes failures easier to reproduce in ordinary Rust tests.
+
+## Windows Host Validation
+
+Use host validation when you need to prove the DLL works with the real WSL service:
+
+1. Build the target example in release mode.
+2. Sign the DLL.
+3. Register the DLL under the WSL plugins registry key.
+4. Restart the WSL service.
+5. Run a WSL command that triggers the plugin.
+6. Inspect plugin output and any expected side effects.
+
+For the minimal example, the observable output is written to `C:\wsl-plugin-demo.txt`.
+
+For your own plugin, choose an observable result that fits the behavior: a log file, an allowed or
+blocked operation, a command output, or another side effect that confirms the expected hook ran.

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -53,6 +53,9 @@ wsl.exe echo "vm startup test"
 wsl.exe -d Ubuntu -- echo "distribution startup test"
 ```
 
+For more WSL command examples, see Microsoft's
+[basic WSL commands](https://learn.microsoft.com/en-us/windows/wsl/basic-commands) documentation.
+
 After rebuilding or changing the registry value, restart the WSL service before testing again:
 
 ```powershell

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -45,3 +45,19 @@ For the minimal example, the observable output is written to `C:\wsl-plugin-demo
 
 For your own plugin, choose an observable result that fits the behavior: a log file, an allowed or
 blocked operation, a command output, or another side effect that confirms the expected hook ran.
+
+Use commands that trigger the hook you are validating:
+
+```powershell
+wsl.exe echo "vm startup test"
+wsl.exe -d Ubuntu -- echo "distribution startup test"
+```
+
+After rebuilding or changing the registry value, restart the WSL service before testing again:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+```
+
+If the plugin does not load or the expected hook does not run, use the
+[Troubleshooting](./troubleshooting.md) chapter before changing the plugin code.

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -1,0 +1,146 @@
+# Troubleshooting
+
+This page maps common WSL plugin failures to the first checks to run. Start with the registered DLL
+path, signature, WSL service restart, and API version before changing plugin logic.
+
+## Plugin Does Not Load
+
+Error:
+
+```text
+Wsl/Service/CreateInstance/CreateVm/Plugin/ERROR_MOD_NOT_FOUND
+```
+
+Likely causes:
+
+- the registry value points to the wrong path;
+- the DLL was rebuilt under a different crate name;
+- a native dependency of the DLL is missing.
+
+Check the registered path:
+
+```powershell
+Get-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins"
+```
+
+Check that the DLL exists:
+
+```powershell
+Test-Path "C:\path\to\plugin.dll"
+```
+
+Remember that Cargo converts hyphens to underscores for library artifact names. A crate named
+`my-wsl-plugin` produces `my_wsl_plugin.dll`.
+
+## Signature Is Rejected
+
+Error:
+
+```text
+Wsl/Service/CreateInstance/CreateVm/Plugin/TRUST_E_NOSIGNATURE
+```
+
+Likely causes:
+
+- the DLL is unsigned;
+- the signing certificate is not trusted by the machine;
+- Windows test signing is required for the development scenario.
+
+Check the signature:
+
+```powershell
+Get-AuthenticodeSignature "C:\path\to\plugin.dll"
+```
+
+For local development, sign with a test certificate and trust it on the test machine. If WSL still
+rejects the DLL, Microsoft documentation may require test signing:
+
+```powershell
+Bcdedit.exe -set TESTSIGNING ON
+```
+
+A reboot may be required. If Secure Boot blocks the setting, decide whether disabling Secure Boot is
+acceptable for that machine before continuing.
+
+## Hook Does Not Run
+
+Likely causes:
+
+- the DLL was registered after WSL had already loaded plugins;
+- the event you are testing does not trigger the hook you implemented;
+- the hook requires a newer WSL plugin API version than the host provides.
+
+Restart the service after registration or rebuilds:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+```
+
+Then run a command that creates the lifecycle event you need. For VM startup hooks, a simple command
+is enough:
+
+```powershell
+wsl.exe echo "test"
+```
+
+For distribution startup hooks, target a specific distribution:
+
+```powershell
+wsl.exe -d Ubuntu -- echo "test"
+```
+
+## WSL Reports Plugin Error
+
+Errors under these paths usually mean the plugin returned an error:
+
+```text
+Wsl/Service/CreateInstance/CreateVm/Plugin/*
+Wsl/Service/CreateInstance/Plugin/*
+```
+
+Check which hook can fail in that path:
+
+- `CreateVm/Plugin/*`: entry point initialization or `on_vm_started`;
+- `CreateInstance/Plugin/*`: `on_distribution_started`.
+
+Use `PluginResult` with a message for user-facing policy failures. Use ordinary `Result` handling
+for I/O, parsing, and WSL API calls instead of panicking.
+
+## Runtime API Is Too Old
+
+If the plugin requests a newer API version than WSL provides, initialization fails with
+`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+
+Use the version in `#[wsl_plugin_v1(major, minor, revision)]` as the minimum API version for the
+plugin as a whole. Keep it as low as practical, and use runtime `Result` checks for optional fields
+or optional behavior.
+
+Common version-sensitive features include:
+
+| Feature | Minimum API version |
+| --- | --- |
+| `init_pid()` | `2.0.5` |
+| Distribution registration hooks | `2.1.2` |
+| `ExecuteBinaryInDistribution` | `2.1.2` |
+| `flavor()` and `version()` | `2.4.4` |
+
+## Cleanup After a Bad Deployment
+
+Remove the registry value and restart WSL:
+
+```powershell
+Remove-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name "my-wsl-plugin" `
+    -Force
+
+Stop-Service -Name "wslservice" -Force
+```
+
+If WSL still behaves unexpectedly, verify that no other plugin values remain under the plugins key:
+
+```powershell
+Get-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins"
+```

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -105,7 +105,9 @@ Check which hook can fail in that path:
 - `CreateInstance/Plugin/*`: `on_distribution_started`.
 
 Use `PluginResult` with a message for user-facing policy failures. Use ordinary `Result` handling
-for I/O, parsing, and WSL API calls instead of panicking.
+for I/O, parsing, and WSL API calls instead of panicking. See
+[Error Handling](./error-handling.md) for the difference between plugin diagnostics and plain
+Windows errors.
 
 ## Runtime API Is Too Old
 

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -1,0 +1,179 @@
+# WSL Plugin Model
+
+WSL plugins are native DLLs loaded by the WSL service. The WSL plugin API calls exported functions
+from the DLL and sends synchronous notifications for lifecycle events.
+
+`wslplugins-rs` turns that model into a Rust trait:
+
+- `try_new` creates the plugin state.
+- `on_vm_started` runs after a VM starts.
+- `on_vm_stopping` runs before a VM stops.
+- `on_distribution_started` runs after a distribution starts.
+- `on_distribution_stopping` runs before a distribution stops.
+- `on_distribution_registered` runs when a distribution is registered.
+- `on_distribution_unregistered` runs when a distribution is unregistered.
+
+The default hook implementations do nothing and return success, so a plugin only implements the
+events it needs.
+
+## What WSL Loads
+
+At the ABI level, a plugin exposes the `WSLPluginAPIV1_EntryPoint` entry point. WSL passes that
+entry point a `WSLPluginAPIV1` table and expects the plugin to fill a `WSLPluginHooksV1` table with
+the callbacks it wants to handle.
+
+The `#[wsl_plugin_v1(...)]` macro generates this entry point and hook table wiring for an
+implementation of `WSLPluginV1`. Most plugin crates should use the macro instead of writing the
+entry point manually.
+
+The API table contains:
+
+- the WSL plugin API version currently offered by the host;
+- `MountFolder`, for creating a Plan 9 mount between Windows and Linux;
+- `ExecuteBinary`, for running a program in the root namespace of the WSL2 VM;
+- `PluginError`, for passing a user-facing failure message back to WSL;
+- `ExecuteBinaryInDistribution`, introduced in API version `2.1.2`, for running a program inside a
+  user distribution.
+
+The hook table contains VM lifecycle hooks, distribution lifecycle hooks, and distribution
+registration hooks. The registration hooks were introduced in API version `2.1.2`.
+
+## Plugin State
+
+The plugin type owns state that must live for the loaded plugin lifetime. The WSL context gives
+access to the API wrapper:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+pub(crate) struct Plugin {
+    context: &'static WSLContext,
+}
+```
+
+The trait requires `Sync` because the host may call plugin hooks from service-owned execution paths.
+Shared state should use synchronization primitives that are appropriate for service code and should
+avoid long blocking critical sections.
+
+The raw WSL structs passed to hooks are borrowed from WSL. The Microsoft header documents those
+pointers as valid only while the hook call is in progress. `wslplugins-rs` exposes typed wrapper
+references for those values, but the same lifetime rule still matters: copy out the data you need if
+it must outlive the hook.
+
+## API Wrappers
+
+The public crate provides typed wrappers for common WSL concepts:
+
+- `WSLContext`: plugin context and access to `ApiV1`.
+- `WSLSessionInformation`: current WSL session metadata.
+- `WSLDistributionInformation`: online distribution metadata.
+- `WSLOfflineDistributionInformation`: offline distribution metadata used by registration hooks.
+- `WSLVmCreationSettings`: VM creation settings.
+- `SessionID`, `DistributionID`, and `UserDistributionID`: typed identifiers.
+- `WSLVersion`: parsed WSL version values.
+
+Prefer these wrappers over raw FFI types in plugin code. Raw access is available behind the `sys`
+feature for cases where a wrapper does not yet expose the needed API.
+
+Online and offline distribution wrappers both implement `CoreWSLDistributionInformation`. That gives
+common access to the distribution ID, name, optional package family name, flavor, and version. The
+crate checks the runtime API version for fields that were added later: `init_pid()` requires
+`2.0.5`, and `flavor()` / `version()` require `2.4.4`.
+
+## Versioned Hooks
+
+Some hooks are only available in newer WSL plugin API versions. For example, distribution
+registration hooks are documented in this crate as introduced in API version `2.1.2`.
+
+Choose the version passed to `#[wsl_plugin_v1(...)]` according to the hooks and API calls your
+plugin uses. A plugin that only handles basic VM lifecycle events can target an older version than a
+plugin that observes distribution registration.
+
+The macro accepts `major, minor` or `major, minor, revision`. If the revision is omitted, it is
+treated as `0`.
+
+If WSL offers an older API version than the one requested by the plugin macro, initialization fails
+with `WSL_E_PLUGIN_REQUIRES_UPDATE`. This is preferable to registering callbacks that rely on fields
+or function pointers the host does not provide.
+
+## Version Checks
+
+`wslplugins-rs` uses two complementary version checks.
+
+The first check happens when WSL loads the DLL. The version passed to
+`#[wsl_plugin_v1(...)]` is the minimum API version required by the plugin as a whole. During entry
+point initialization, the generated code compares that requirement with `context.api.version()`. If
+the runtime API is too old, plugin creation stops and WSL receives
+`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+
+That means WSL does not call `try_new` and the hook table is not registered for that plugin. A hook
+that requires a newer API version will therefore never be called if you declare that version in the
+macro and the host runtime is older. This is the right choice for features that are central to the
+plugin's behavior.
+
+Hook availability is decided when the plugin is registered with WSL, not lazily when an event
+happens. If the current WSL plugin API version does not provide a hook slot, the method associated
+with that event is never called. For example, on a runtime older than `2.1.2`, distribution
+registration and unregistration notifications are not available, so
+`on_distribution_registered` and `on_distribution_unregistered` cannot run.
+
+The second check happens at runtime on individual APIs or fields. Some wrappers return a `Result`
+instead of silently reading a field that may not exist on the current WSL API version:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+fn describe_distribution(distribution: &WSLDistributionInformation) -> PluginResult<String> {
+    let init_pid = distribution.init_pid()?;
+    Ok(format!(
+        "{} is running with init PID {init_pid}",
+        distribution.name().to_string_lossy()
+    ))
+}
+```
+
+If the runtime API is too old for `init_pid()`, the call returns a `RequiresUpdate` error that maps
+to `WSL_E_PLUGIN_REQUIRES_UPDATE`. The same pattern is used by distribution-scoped command
+execution: `ExecuteBinaryInDistribution` requires API version `2.1.2`, so
+`with_distribution_id(DistributionID::User(...)).execute()` can return an API error on an older
+runtime.
+
+Use runtime `Result` checks when the feature is optional:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> {
+    distribution
+        .flavor()
+        .ok()
+        .flatten()
+        .map(|value| value.to_string_lossy().into_owned())
+}
+```
+
+Use the macro version requirement when the plugin cannot behave correctly without the newer hook,
+field, or API call. For example, a plugin whose main purpose is to run commands inside a specific
+user distribution should require at least `2.1.2`; a plugin that only uses `flavor()` as a nicer log
+detail can keep a lower macro version and treat that field as optional.
+
+## Hook Failure Semantics
+
+Most hook failures are treated as lifecycle failures by WSL. For example, an error from
+`OnVMStarted` or `OnDistributionStarted` can prevent the VM or distribution from starting.
+
+Distribution registration notifications are different in the current Microsoft header: failures from
+`OnDistributionRegistered` and `OnDistributionUnregistered` do not cause the register or unregister
+operation itself to fail. Use those hooks for observation, cleanup, indexing, or best-effort policy
+work. If you need to block startup, enforce that policy in a startup hook instead.
+
+## External References
+
+- Microsoft WSL plugin documentation:
+  <https://learn.microsoft.com/en-us/windows/wsl/wsl-plugins>
+- Microsoft WSL Plugin API NuGet package:
+  <https://www.nuget.org/packages/Microsoft.WSL.PluginApi>
+- Microsoft WSL plugin sample:
+  <https://github.com/microsoft/wsl-plugin-sample>


### PR DESCRIPTION
## Summary

- Add an mdBook user guide for wslplugins-rs.
- Explain the user-facing development flow from a first plugin to packaging and host validation.

## Changes

- Added the mdBook structure and user guide chapters.
- Documented plugin lifecycle, version checks, FFI safety, testing, and packaging.
- Added a GitHub Pages workflow for the book.
- Added README links to the book and docs.rs.
- Added a PR template validation item for book changes.
- Added AGENTS.md guidance to keep the book current when user-facing behavior changes.
- No public API or runtime behavior changes.

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [x] Documentation
- [ ] Examples
- [x] CI / release workflow
- [x] AGENTS.md instructions

## Validation

- [ ] `cargo test --workspace --all-features`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo fmt --all -- --check`
- [x] `mdbook build book` when the book is changed
- [ ] Relevant manual testing completed

## WSL / Windows Notes

- This is a documentation and CI workflow change.
- It does not affect plugin loading, signing, registration, or Windows-only runtime behavior.
- No host-affecting WSL validation was run.

## Checklist

- [ ] Tests added or updated when relevant
- [x] Documentation updated when relevant
- [ ] Examples updated when relevant
- [x] No unrelated changes included
