### PR TITLE
Release 0.1.0-beta.4

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@
 - [ ] `cargo test --workspace --all-features`
 - [ ] `cargo clippy --workspace --all-targets --all-features`
 - [ ] `cargo fmt --all -- --check`
+- [ ] `mdbook build book` when the book is changed
 - [ ] Relevant manual testing completed
 
 ## WSL / Windows Notes
@@ -36,5 +37,6 @@
 
 - [ ] Tests added or updated when relevant
 - [ ] Documentation updated when relevant
+- [ ] Book updated as needed for public API changes, or the PR explains why no book update is needed
 - [ ] Examples updated when relevant
 - [ ] No unrelated changes included

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -103,7 +103,7 @@ jobs:
 
   build-pages:
     name: Build Pages artifact
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs:
       - build
       - test-snippets
@@ -145,7 +145,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs: build-pages
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,157 @@
+name: Book
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - release/*
+    paths:
+      - book/**
+      - .github/workflows/book.yml
+  pull_request:
+    branches:
+      - main
+      - develop
+      - release/*
+    paths:
+      - book/**
+      - .github/workflows/book.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  test-snippets:
+    name: Test Rust snippets
+    runs-on: windows-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: -D warnings
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo Git Index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      - name: Install Rust
+        shell: pwsh
+        run: rustup update stable && rustup default stable
+
+      - name: Install mdbook
+        run: cargo install mdbook
+
+      - name: Build snippet dependencies
+        run: cargo build -p wslplugins-rs --features macro
+        env:
+          CARGO_TARGET_DIR: .tmp/book-doctest-target
+
+      - name: Test Rust snippets
+        run: mdbook test book -L .tmp/book-doctest-target/debug/deps
+
+  build:
+    name: Build mdBook
+    runs-on: windows-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo Git Index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      - name: Install Rust
+        shell: pwsh
+        run: rustup update stable && rustup default stable
+
+      - name: Install mdbook
+        run: cargo install mdbook
+
+      - name: Build
+        run: mdbook build book
+
+  build-pages:
+    name: Build Pages artifact
+    if: github.event_name != 'pull_request'
+    needs:
+      - build
+      - test-snippets
+    runs-on: windows-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo Registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo Git Index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      - name: Install Rust
+        shell: pwsh
+        run: rustup update stable && rustup default stable
+
+      - name: Install mdbook
+        run: cargo install mdbook
+
+      - name: Build
+        run: mdbook build book
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/book
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build-pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ Use Rust 2021 and the repository `rustfmt.toml` settings. Use `snake_case` for c
 
 Place ordinary Rust tests next to the code or in crate-level `tests/` directories. Macro behavior belongs in `crates/wslplugins-macro-tests/tests/`, with UI fixtures under `tests/ui/`. Name tests after behavior, for example `formats_user_distribution_id_as_guid`. Run the full workspace test command before opening a pull request that changes code.
 
+## Documentation Guidelines
+
+The mdBook in `book/` is the user-oriented guide for this library. When changing the public API, update the book as much as needed so users can understand the new or changed API surface. Also update the book when changing examples, plugin behavior, packaging, validation, or anything users need to understand to build WSL plugins. If a change intentionally does not require a book update, make that explicit in the pull request.
+
 ## Git Flow & Pull Requests
 
 Git Flow applies to published library crates: `develop` carries versioned crate work, while `main` remains the stable branch. Create `feature/*` and `fix/*` branches from `develop`, and target their pull requests back to `develop`. Use `release/*` branches for versioned release preparation, final validation, and publishing dry runs before merging to `main` and back to `develop`.
@@ -44,4 +48,3 @@ Recent commits use short imperative or descriptive subjects, often with PR numbe
 ## Security & Configuration Tips
 
 Do not commit private certificates, keys, signed DLLs, or machine-specific registry paths. Treat `sign-plugin.ps1 -Trust`, registry edits, and WSL service restarts as host-affecting operations.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,8 @@ Good pull request descriptions usually include:
 - Test results for the checks that were run.
 - Windows validation notes when the change was actually tested with WSL.
 
+When a pull request changes the public API, update the mdBook in `book/` as much as needed so users can understand the new or changed API surface. If no book update is needed for a public API change, explain why in the pull request.
+
 Keep commits focused. Recent commit subjects use short imperative or descriptive wording, for example:
 
 ```text

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strum = { version = "0.28", features = ["derive"] }
 
 [workspace.package]
 authors = ["Mickaël Véril <mika.veril@wanadoo.fr>"]
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.4"
 readme = "README.md"
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ quote = "1"
 syn = "2"
 proc-macro2 = "1"
 smallvec = "1" 
+strum = { version = "0.28", features = ["derive"] }
 
 [workspace.package]
 authors = ["Mickaël Véril <mika.veril@wanadoo.fr>"]

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pub(crate) struct MyPlugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -88,6 +88,56 @@ impl WSLPluginV1 for MyPlugin {
 ```
 
 The `macro` feature re-exports the `wsl_plugin_v1` attribute and generates the WSL entry points for a `WSLPluginV1` implementation.
+
+### Choosing API Requirements
+
+The macro argument controls the WSL Plugin API support checked before your plugin is initialized.
+Use no argument when the plugin only needs the base entry point:
+
+```rust
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct MyPlugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1]
+impl WSLPluginV1 for MyPlugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+Use `#[wsl_plugin_v1(major, minor)]` or `#[wsl_plugin_v1(major, minor, revision)]` when the whole
+plugin requires a known API version before it can run.
+
+For plugins that require named API capabilities, pass one or more
+`WSLVersionCapability` values:
+
+```rust
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct RegistrationLogger {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(
+    WSLVersionCapability::DistributionRegisteredHook
+    | WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for RegistrationLogger {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+Hooks introduced after the base API, such as distribution registration and
+unregistration notifications, are wired only when the host API version supports
+the corresponding capability. See the book's
+[Version Capabilities](https://mveril.github.io/wslplugins-rs/version-capabilities.html) chapter
+for the capability list and cross-references to command execution and plugin events.
 
 ## Running Commands in WSL
 
@@ -112,16 +162,19 @@ Notes:
 
 - Program paths must be Linux UTF-8 paths such as `/bin/echo`
 - `argv[0]` defaults to the program path and can be overridden with `with_arg0`
-- `with_distribution_id` targets a specific user distribution
+- `with_distribution_id` targets a specific user distribution and requires the
+  `ExecuteBinaryInDistribution` capability
 - `execute()` returns a `TcpStream` connected to process stdin/stdout
 - stderr is forwarded to Linux `dmesg`
 
 ## Examples
 
-Two example plugins are included:
+Example plugins are included:
 
 - `examples/minimal`: a close Rust translation of Microsoft's sample plugin
 - `examples/dist-info`: a plugin focused on distribution metadata and tracing
+- `examples/unpackaged-distro-blacklist-policy`: a policy plugin that blocks unpackaged
+  distributions
 
 Build one of them in release mode:
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Add the crate with the `macro` feature:
 
 ```toml
 [dependencies]
-wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+wslplugins-rs = { version = "0.1.0-beta.4", features = ["macro"] }
 ```
 
 Then implement a plugin:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/wslplugins-rs?logo=rust)](https://crates.io/crates/wslplugins-rs)
 [![Docs.rs](https://img.shields.io/badge/docs.rs-wslplugins--rs-blue?logo=docs.rs)](https://docs.rs/wslplugins-rs)
+[![Book](https://img.shields.io/badge/book-mdBook-blue?logo=mdbook)](https://mveril.github.io/wslplugins-rs/)
 [![Build Status](https://github.com/mveril/wslplugins-rs/actions/workflows/rust.yml/badge.svg?logo=github)](https://github.com/mveril/wslplugins-rs/actions)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE-APACHE)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
@@ -46,6 +47,19 @@ The workspace is organized around a small public API surface and separate macro 
 - `wslplugins-macro-tests`: compile-time tests for macro-generated plugin code.
 
 This split keeps plugin authors focused on `wslplugins-rs`, while the macro parsing and generated WSL entry-point wiring stay isolated in internal crates.
+
+## Documentation
+
+- [The wslplugins-rs Book](https://mveril.github.io/wslplugins-rs/) explains the development flow from first plugin to packaging.
+- [docs.rs](https://docs.rs/wslplugins-rs) contains the generated API reference.
+
+To build the book locally, install [mdBook](https://rust-lang.github.io/mdBook/guide/installation.html)
+with Cargo and run:
+
+```powershell
+cargo install mdbook
+mdbook build book
+```
 
 ## Quick Start
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,13 @@
+[book]
+title = "The wslplugins-rs Book"
+authors = ["Mickaël Véril"]
+language = "en"
+src = "src"
+
+[build]
+build-dir = "../target/book"
+
+[output.html]
+git-repository-url = "https://github.com/mveril/wslplugins-rs"
+edit-url-template = "https://github.com/mveril/wslplugins-rs/edit/main/book/{path}"
+site-url = "/wslplugins-rs/"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [End-to-End Quickstart](./quickstart.md)
 - [Your First Plugin](./first-plugin.md)
 - [WSL Plugin Model](./wsl-plugin-model.md)
+- [Version Capabilities](./version-capabilities.md)
 - [Error Handling](./error-handling.md)
 - [Command Execution](./command-execution.md)
 - [FFI and Safety](./ffi-and-safety.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,16 @@
+# Summary
+
+- [Introduction](./introduction.md)
+
+# User Guide
+
+- [Getting Started](./getting-started.md)
+- [End-to-End Quickstart](./quickstart.md)
+- [Your First Plugin](./first-plugin.md)
+- [WSL Plugin Model](./wsl-plugin-model.md)
+- [Error Handling](./error-handling.md)
+- [Command Execution](./command-execution.md)
+- [FFI and Safety](./ffi-and-safety.md)
+- [Testing](./testing.md)
+- [Packaging and Deployment](./packaging.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/book/src/command-execution.md
+++ b/book/src/command-execution.md
@@ -1,0 +1,44 @@
+# Command Execution
+
+`ApiV1::new_command` builds a Linux command to run in a WSL session. The program path and arguments
+must be valid for the target Linux environment:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_FAIL: HRESULT = HRESULT(0x80004005u32 as i32);
+
+fn read_kernel_version(
+    context: &WSLContext,
+    session: &WSLSessionInformation,
+) -> PluginResult<String> {
+    let mut stream = context
+        .api
+        .new_command(session, "/bin/cat")
+        .with_arg("/proc/version")
+        .execute()?;
+
+    let mut kernel_version = String::new();
+    std::io::Read::read_to_string(&mut stream, &mut kernel_version).map_err(|error| {
+        PluginError::with_message(E_FAIL, OsString::from(error.to_string()))
+    })?;
+
+    Ok(kernel_version)
+}
+```
+
+The returned stream is connected to stdin and stdout. Drop it when no more interaction is needed.
+
+By default, `WSLCommand` targets the system/root namespace through the WSL API `ExecuteBinary`. This
+namespace is not the same as a user distribution. Microsoft documents it as a minimal Mariner-based
+root filesystem backed by writable `tmpfs`, so changes made there disappear when the WSL2 VM shuts
+down.
+
+Use a user-distribution target when the command must run inside a distribution rather than the root
+namespace. That path uses `ExecuteBinaryInDistribution`, which requires API version `2.1.2` or newer.
+
+The returned `TcpStream` is connected to the command's stdin and stdout. It does not carry stderr;
+WSL sends stderr output to Linux `dmesg`.

--- a/book/src/command-execution.md
+++ b/book/src/command-execution.md
@@ -38,7 +38,10 @@ root filesystem backed by writable `tmpfs`, so changes made there disappear when
 down.
 
 Use a user-distribution target when the command must run inside a distribution rather than the root
-namespace. That path uses `ExecuteBinaryInDistribution`, which requires API version `2.1.2` or newer.
+namespace. That path uses `ExecuteBinaryInDistribution`, which is represented by
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`). If that command path is central to the plugin, declare the capability in
+`#[wsl_plugin_v1(...)]`. If it is optional, handle the error returned by `execute()`.
 
 The returned `TcpStream` is connected to the command's stdin and stdout. It does not carry stderr;
 WSL sends stderr output to Linux `dmesg`.

--- a/book/src/error-handling.md
+++ b/book/src/error-handling.md
@@ -1,0 +1,61 @@
+# Error Handling
+
+WSL plugins run inside the WSL service process, so failures should be explicit errors instead of
+process-level failures. Return errors instead of panicking:
+
+- use `WinResult<T>` for Windows API style errors;
+- use `PluginResult<T>` for plugin hook errors;
+- map I/O errors into Windows errors where required by the hook signature;
+- avoid `panic!`, `unwrap`, and `expect` in plugin code.
+
+Panics are a poor fit for WSL plugins because the plugin is loaded inside a WSL service process, not
+inside a short-lived CLI that only affects its own execution. A panic in a hook can unwind through an
+FFI boundary, abort the process, poison shared state, or leave WSL with only a generic failure code.
+The host is also allowed to call hooks during lifecycle operations such as VM startup, distribution
+registration, or shutdown; failing predictably is more useful than terminating the service path.
+
+Avoiding `unwrap` and `expect` is part of the same rule. A missing field, inaccessible file, invalid
+distribution name, or failed command execution should become an explicit error that WSL can report
+or handle. It should not become an accidental process failure.
+
+## Plugin Errors and Windows Errors
+
+`wslplugins-rs` exposes two result styles because WSL has two different error channels:
+
+- `WinResult<T>` returns a normal Windows `HRESULT` to the host.
+- `PluginResult<T>` returns `PluginError`, which contains an `HRESULT` and an optional message.
+
+Use `WinResult<T>` when the hook signature is purely Windows-style or when only an error code is
+expected. Use `PluginResult<T>` where the framework hook supports a plugin-level diagnostic message.
+
+When a `PluginError` has a message, the framework sends that message to WSL through the plugin API
+before converting the error back into a Windows error code. That gives WSL a human-readable plugin
+diagnostic instead of only an `HRESULT`. In practice, this is useful for policy-style failures where
+the user should see why an operation was denied:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_ACCESSDENIED: HRESULT = HRESULT(0x80070005u32 as i32);
+
+fn reject_distribution(name: &str) -> PluginResult<()> {
+    Err(PluginError::with_message(
+        E_ACCESSDENIED,
+        OsString::from(format!(
+            "Distribution '{name}' is blocked by local policy"
+        )),
+    ))
+}
+```
+
+If you convert everything to `windows_core::Error` too early, WSL still receives the failure code,
+but it can lose the plugin-specific explanation. Prefer `PluginResult` for hooks where the message
+is part of the user experience.
+
+The raw `PluginError` API is intended for synchronous use while WSL is processing VM or distribution
+creation. In practice, use `PluginResult` from `on_vm_started` and `on_distribution_started` when a
+message should be shown to the user. Do not store a delayed error message and try to report it after
+the hook has returned.

--- a/book/src/ffi-and-safety.md
+++ b/book/src/ffi-and-safety.md
@@ -50,9 +50,8 @@ keep these header-level rules in mind:
 - hook input pointers are valid only during the callback;
 - string pointers from WSL may be null where the header allows it, such as `PackageFamilyName`;
 - `ExecuteBinary` argument arrays are null-terminated at the ABI boundary;
-- `WSLDistributionInformation::InitPid` was introduced in API version `2.0.5`;
-- `Flavor` and `Version` exist in the current header; `wslplugins-rs` exposes them through
-  `flavor()` and `version()` and currently requires API version `2.4.4` before reading them.
+- some fields and function pointers are available only when the host API supports the matching
+  `WSLVersionCapability`; see [Version Capabilities](./version-capabilities.md).
 
 These details are useful when debugging ABI mismatches, but ordinary plugin logic should stay on the
 typed Rust side.

--- a/book/src/ffi-and-safety.md
+++ b/book/src/ffi-and-safety.md
@@ -1,0 +1,58 @@
+# FFI and Safety
+
+WSL plugins run inside the WSL service process. A crash, panic across an FFI boundary, invalid
+pointer, or blocking hook can affect the host service. Treat plugin code like systems code even when
+using safe Rust wrappers.
+
+Because hooks cross an FFI boundary, plugin code should return typed errors instead of panicking.
+See [Error Handling](./error-handling.md) for the `WinResult` and `PluginResult` conventions.
+
+## Unsafe Code
+
+Most plugin code should not need raw FFI access. When unsafe code is necessary:
+
+- keep unsafe blocks as small as possible;
+- document each block with a `SAFETY:` comment;
+- validate pointer lifetimes and ownership before wrapping raw values;
+- avoid storing borrowed FFI data beyond the lifetime guaranteed by WSL.
+
+The `wslplugins-rs` crate centralizes raw API handling so plugin authors can usually work with typed
+Rust values instead.
+
+## Hook Behavior
+
+Hooks are synchronous notifications. Keep them predictable:
+
+- do the minimum required work in the hook;
+- avoid unbounded waits;
+- avoid holding locks while calling into WSL APIs;
+- make logging best-effort and failure-aware;
+- assume hooks may be called multiple times for lifecycle retries.
+
+If a plugin needs heavier work, prefer moving it to a controlled background path with clear
+shutdown behavior.
+
+Microsoft's WSL plugin documentation calls out three operational consequences of this model:
+
+- WSL waits for hook callbacks before continuing the lifecycle operation.
+- Most plugin errors are fatal to the VM or distribution startup path.
+- Plugin code runs in the WSL service process, so a plugin crash can crash the service.
+
+That is why the framework examples keep hooks small and use typed errors instead of process-level
+failure mechanisms.
+
+## Advanced FFI Notes
+
+The `sys` feature re-exports the raw `wslpluginapi-sys` bindings for cases where the safe wrapper
+does not yet expose a field or function. Prefer the safe wrapper first. If raw access is necessary,
+keep these header-level rules in mind:
+
+- hook input pointers are valid only during the callback;
+- string pointers from WSL may be null where the header allows it, such as `PackageFamilyName`;
+- `ExecuteBinary` argument arrays are null-terminated at the ABI boundary;
+- `WSLDistributionInformation::InitPid` was introduced in API version `2.0.5`;
+- `Flavor` and `Version` exist in the current header; `wslplugins-rs` exposes them through
+  `flavor()` and `version()` and currently requires API version `2.4.4` before reading them.
+
+These details are useful when debugging ABI mismatches, but ordinary plugin logic should stay on the
+typed Rust side.

--- a/book/src/first-plugin.md
+++ b/book/src/first-plugin.md
@@ -1,0 +1,96 @@
+# Your First Plugin
+
+The minimal shape of a plugin is a Rust `cdylib` crate containing a type plus an implementation of
+`WSLPluginV1`.
+The `#[wsl_plugin_v1(...)]` macro generates the exported functions and hook wiring expected by WSL.
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct MyPlugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 0, 5)]
+impl WSLPluginV1 for MyPlugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+The version in `#[wsl_plugin_v1(major, minor, revision)]` declares the WSL plugin API version
+required by the plugin. The revision component is optional and defaults to `0`. Use the lowest
+version that provides the hooks and API calls your plugin needs.
+
+The `context` gives access to the framework API wrapper. Store it if the plugin needs to call WSL
+APIs later from hook methods.
+
+## Add Hooks
+
+Hooks are regular trait methods. Override only the lifecycle events the plugin needs:
+
+```rust
+# extern crate wslplugins_rs;
+use std::ffi::OsString;
+use wslplugins_rs::prelude::*;
+use wslplugins_rs::windows_core::HRESULT;
+
+const E_FAIL: HRESULT = HRESULT(0x80004005u32 as i32);
+
+pub(crate) struct MyPlugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for MyPlugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+
+    fn on_vm_started(
+        &self,
+        session: &WSLSessionInformation,
+        user_settings: &WSLVmCreationSettings,
+    ) -> PluginResult<()> {
+        let mut stream = self
+            .context
+            .api
+            .new_command(session, "/bin/cat")
+            .with_arg("/proc/version")
+            .execute()?;
+
+        let mut kernel_version = String::new();
+        std::io::Read::read_to_string(&mut stream, &mut kernel_version).map_err(|error| {
+            PluginError::with_message(E_FAIL, OsString::from(error.to_string()))
+        })?;
+        Ok(())
+    }
+}
+```
+
+Command paths are Linux paths such as `/bin/cat`. `execute()` returns a `TcpStream` connected to the
+process stdin and stdout; stderr is forwarded to Linux `dmesg`.
+
+## Start from an Example
+
+If you want a complete working reference, start with the `minimal` example from the repository. It
+demonstrates:
+
+- creating plugin state in `try_new`;
+- logging VM and distribution lifecycle events;
+- running `/bin/cat /proc/version` when the VM starts;
+- using `#[wsl_plugin_v1(2, 1, 3)]` because it handles distribution registration hooks. Those
+  hooks are available starting with API version `2.1.2`; the example currently targets `2.1.3`.
+
+In your own plugin crate, the equivalent release build is:
+
+```powershell
+cargo build --release
+```
+
+After that, sign and register the DLL as described in the packaging chapter.
+
+Next: read [WSL Plugin Model](./wsl-plugin-model.md) for the host model and versioning rules, or
+jump to [Packaging and Deployment](./packaging.md) when you are ready to load the DLL into WSL.

--- a/book/src/first-plugin.md
+++ b/book/src/first-plugin.md
@@ -2,7 +2,7 @@
 
 The minimal shape of a plugin is a Rust `cdylib` crate containing a type plus an implementation of
 `WSLPluginV1`.
-The `#[wsl_plugin_v1(...)]` macro generates the exported functions and hook wiring expected by WSL.
+The `#[wsl_plugin_v1]` macro generates the exported functions and hook wiring expected by WSL.
 
 ```rust
 # extern crate wslplugins_rs;
@@ -12,7 +12,7 @@ pub(crate) struct MyPlugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -20,9 +20,9 @@ impl WSLPluginV1 for MyPlugin {
 }
 ```
 
-The version in `#[wsl_plugin_v1(major, minor, revision)]` declares the WSL plugin API version
-required by the plugin. The revision component is optional and defaults to `0`. Use the lowest
-version that provides the hooks and API calls your plugin needs.
+Use a requirement in `#[wsl_plugin_v1(...)]` only when the whole plugin depends on a specific WSL
+Plugin API version or named capability. See [Version Capabilities](./version-capabilities.md) for
+the supported forms and feature gates.
 
 The `context` gives access to the framework API wrapper. Store it if the plugin needs to call WSL
 APIs later from hook methods.
@@ -43,7 +43,7 @@ pub(crate) struct MyPlugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 1, 2)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -71,7 +71,8 @@ impl WSLPluginV1 for MyPlugin {
 ```
 
 Command paths are Linux paths such as `/bin/cat`. `execute()` returns a `TcpStream` connected to the
-process stdin and stdout; stderr is forwarded to Linux `dmesg`.
+process stdin and stdout; stderr is forwarded to Linux `dmesg`. This example runs in the VM root
+namespace; see [Command Execution](./command-execution.md) for distribution-scoped execution.
 
 ## Start from an Example
 
@@ -81,8 +82,9 @@ demonstrates:
 - creating plugin state in `try_new`;
 - logging VM and distribution lifecycle events;
 - running `/bin/cat /proc/version` when the VM starts;
-- using `#[wsl_plugin_v1(2, 1, 3)]` because it handles distribution registration hooks. Those
-  hooks are available starting with API version `2.1.2`; the example currently targets `2.1.3`.
+- using the macro to declare plugin-wide requirements when a hook or API capability is mandatory.
+  New plugins should prefer named capabilities where available; see
+  [Version Capabilities](./version-capabilities.md).
 
 In your own plugin crate, the equivalent release build is:
 
@@ -92,5 +94,5 @@ cargo build --release
 
 After that, sign and register the DLL as described in the packaging chapter.
 
-Next: read [WSL Plugin Model](./wsl-plugin-model.md) for the host model and versioning rules, or
+Next: read [WSL Plugin Model](./wsl-plugin-model.md) for the host model and available events, or
 jump to [Packaging and Deployment](./packaging.md) when you are ready to load the DLL into WSL.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -69,7 +69,7 @@ pub(crate) struct Plugin {
     context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { context })
@@ -79,6 +79,10 @@ impl WSLPluginV1 for Plugin {
 
 Add hook methods only for the events your plugin handles. The default implementation for each hook
 does nothing and returns success.
+
+If a hook or API call is mandatory for the plugin, declare that requirement with
+`#[wsl_plugin_v1(...)]`. Prefer named capabilities where they exist; see
+[Version Capabilities](./version-capabilities.md).
 
 ## Validate During Development
 

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -47,7 +47,7 @@ Most plugins should enable the `macro` feature so the crate generates the requir
 
 ```toml
 [dependencies]
-wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+wslplugins-rs = { version = "0.1.0-beta.4", features = ["macro"] }
 ```
 
 Import the prelude in your plugin code:

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,0 +1,112 @@
+# Getting Started
+
+This chapter assumes you are creating a plugin crate outside this repository and want to consume
+`wslplugins-rs` as a dependency.
+
+If you want the shortest copy-and-run path first, use the
+[End-to-End Quickstart](./quickstart.md), then return here for the background details.
+
+## Prerequisites
+
+Install these tools on Windows:
+
+- [Rust stable and Cargo](https://www.rust-lang.org/tools/install).
+- PowerShell.
+- [`SignTool.exe`](https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool) from the
+  Windows SDK.
+- [WSL installed](https://learn.microsoft.com/en-us/windows/wsl/install) and able to run at least
+  one distribution.
+- A Windows environment that can build native MSVC Rust targets.
+
+`SignTool.exe` is usually easiest to access from a Visual Studio Developer Command Prompt or from a
+shell where the Windows SDK tools are on `PATH`.
+
+Packaging and host validation also require administrator access because local testing can touch the
+machine certificate store, the `HKLM` registry hive, and the WSL service.
+
+## Create a Plugin Crate
+
+Create a Rust library crate and configure it to produce a DLL:
+
+```powershell
+cargo new my-wsl-plugin --lib
+cd my-wsl-plugin
+```
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+The crate can contain normal Rust modules and dependencies. The important requirement is that the
+final artifact is a native Windows DLL that WSL can load.
+
+## Add the Framework
+
+Most plugins should enable the `macro` feature so the crate generates the required WSL exports:
+
+```toml
+[dependencies]
+wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+```
+
+Import the prelude in your plugin code:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+```
+
+## Implement the Plugin
+
+A minimal plugin is a type plus a `WSLPluginV1` implementation:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct Plugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 0, 5)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+Add hook methods only for the events your plugin handles. The default implementation for each hook
+does nothing and returns success.
+
+## Validate During Development
+
+Run ordinary Rust checks while developing:
+
+```powershell
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt -- --check
+```
+
+When you are ready to load the plugin into WSL, build a release DLL:
+
+```powershell
+cargo build --release
+```
+
+The DLL is written under `target\release\` using your crate name.
+
+## Use the Examples
+
+The repository examples show complete plugins for common scenarios:
+
+- `minimal`: lifecycle hooks and command execution inside a WSL session.
+- `dist-info`: distribution metadata access.
+- `unpackaged-distro-blacklist-policy`: a policy-style plugin.
+
+Use them as references for plugin behavior, not as required workspace structure.
+
+Next: follow the [End-to-End Quickstart](./quickstart.md) for a complete deployment loop, or read
+[Your First Plugin](./first-plugin.md) to add hook behavior.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,0 +1,38 @@
+# Introduction
+
+`wslplugins-rs` is a Rust framework for building DLL plugins loaded by Windows Subsystem for Linux.
+It wraps the raw WSL plugin API with Rust types and provides a procedural macro that generates the
+exported entry points and hook registration code expected by WSL.
+
+Use it when your plugin needs to observe WSL lifecycle events, inspect distribution metadata, or run
+commands inside a WSL session from plugin code.
+
+This book is written for plugin authors using the library in their own crate. It focuses on the path
+from an empty Rust plugin project to a signed and registered DLL on Windows. For item-by-item API
+reference, use the generated Rust documentation on docs.rs.
+
+## Design Goals
+
+The framework keeps the plugin authoring model small:
+
+- implement `WSLPluginV1` for a Rust type that owns the plugin state;
+- annotate the implementation with `#[wsl_plugin_v1(...)]`;
+- use typed wrappers for WSL sessions, distributions, versions, and command execution;
+- return errors instead of panicking inside the WSL service process.
+
+WSL loads plugins into a host service process. Reliability and conservative error handling matter
+more than convenience shortcuts. The [Error Handling](./error-handling.md) chapter explains how to
+turn plugin failures into `WinResult` or `PluginResult` values.
+
+## What You Build
+
+A plugin built with `wslplugins-rs` is a Rust library crate compiled as a Windows DLL:
+
+```toml
+[lib]
+crate-type = ["cdylib"]
+```
+
+The DLL is then signed, registered under the WSL plugins registry key, and loaded by the WSL service.
+The examples in the repository are useful starting points, but the same model applies to any plugin
+crate that depends on `wslplugins-rs`.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -16,7 +16,7 @@ reference, use the generated Rust documentation on docs.rs.
 The framework keeps the plugin authoring model small:
 
 - implement `WSLPluginV1` for a Rust type that owns the plugin state;
-- annotate the implementation with `#[wsl_plugin_v1(...)]`;
+- annotate the implementation with `#[wsl_plugin_v1]` or a specific API requirement;
 - use typed wrappers for WSL sessions, distributions, versions, and command execution;
 - return errors instead of panicking inside the WSL service process.
 

--- a/book/src/packaging.md
+++ b/book/src/packaging.md
@@ -1,0 +1,129 @@
+# Packaging and Deployment
+
+WSL loads plugin DLLs from Windows. A development deployment usually has four steps:
+
+1. Build the plugin DLL.
+2. Sign the DLL.
+3. Register the DLL path in the WSL plugins registry key.
+4. Restart the WSL service and trigger plugin loading.
+
+The underlying Microsoft package for the native API is `Microsoft.WSL.PluginApi` on NuGet. Version
+`2.4.4` was the current package version checked on 2026-05-27, and it contains the `WslPluginApi.h`
+header used to define the native ABI. Check NuGet for newer versions when updating bindings or
+comparing against the C header. Rust users normally consume that ABI through `wslplugins-rs` and
+`wslpluginapi-sys`; you do not need to add the NuGet package to a Rust plugin crate unless you are
+comparing against the C header or writing C/C++ interop code.
+
+## Build a DLL
+
+Build your plugin in release mode when you are ready to deploy it locally:
+
+```powershell
+cargo build --release
+```
+
+The resulting DLL is written to `target\release\<crate-name>.dll`.
+
+## Sign the DLL
+
+WSL requires a signed DLL. In a real deployment, sign with the certificate and process used for your
+environment. During local development, you can use a test certificate and `SignTool.exe`.
+
+The repository includes `sign-plugin.ps1` as a development helper. From an elevated PowerShell
+session in a checkout of this repository:
+
+```powershell
+.\sign-plugin.ps1 -PluginPath C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll
+```
+
+To also trust the generated certificate locally:
+
+```powershell
+.\sign-plugin.ps1 -PluginPath C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll -Trust
+```
+
+The `-Trust` option imports the generated certificate into the local machine trusted root store.
+Do not commit generated certificates, private keys, or signed DLLs.
+
+If WSL rejects a locally signed plugin with `TRUST_E_NOSIGNATURE`, Microsoft documentation may
+require Windows test signing on the test machine:
+
+```powershell
+Bcdedit.exe -set TESTSIGNING ON
+```
+
+A reboot may be required after changing test-signing mode.
+
+If `Bcdedit.exe -set TESTSIGNING ON` fails because the value is protected by Secure Boot policy,
+Microsoft's WSL plugin documentation recommends disabling Secure Boot from firmware settings before
+trying again. Consider the security impact before doing that on a daily-use machine.
+
+## Register the Plugin
+
+Register the signed DLL under the WSL plugins registry key:
+
+```powershell
+$PluginName = "my-wsl-plugin"
+$DllPath = "C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll"
+
+Set-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Value $DllPath `
+    -Force
+```
+
+Use a value name and DLL path that match the plugin you are testing.
+
+To unregister the plugin after testing, remove the registry value and restart WSL again:
+
+```powershell
+Remove-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Force
+
+Stop-Service -Name "wslservice" -Force
+```
+
+## Reload WSL
+
+Restart the WSL service, then run a WSL command:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+wsl.exe echo "test"
+```
+
+After loading the plugin, verify:
+
+- the DLL path in the registry;
+- the signature status;
+- the expected plugin logs or side effects;
+- Windows validation notes relevant to the change.
+
+Common WSL plugin load failures include:
+
+- `Wsl/Service/CreateInstance/CreateVm/Plugin/ERROR_MOD_NOT_FOUND`: WSL could not load the DLL.
+  Check the registered path and any native dependencies.
+- `Wsl/Service/CreateInstance/CreateVm/Plugin/TRUST_E_NOSIGNATURE`: the DLL is unsigned or the
+  signing certificate is not trusted by the machine.
+- `Wsl/Service/CreateInstance/CreateVm/Plugin/*`: the plugin returned an error from the entry point
+  or `OnVMStarted`.
+- `Wsl/Service/CreateInstance/Plugin/*`: the plugin returned an error from
+  `OnDistributionStarted`.
+
+Because plugins run in the WSL service process, treat host validation as a machine-affecting test:
+keep a note of the registry value you added, the certificate you trusted, and the service restart
+commands you ran.
+
+For symptom-by-symptom checks, see [Troubleshooting](./troubleshooting.md).
+
+## Sources
+
+- Microsoft WSL plugin documentation:
+  <https://learn.microsoft.com/en-us/windows/wsl/wsl-plugins>
+- Microsoft WSL Plugin API NuGet package:
+  <https://www.nuget.org/packages/Microsoft.WSL.PluginApi>
+- Microsoft WSL plugin sample:
+  <https://github.com/microsoft/wsl-plugin-sample>

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -1,0 +1,131 @@
+# End-to-End Quickstart
+
+This chapter shows the shortest complete path from a new Rust crate to a WSL plugin DLL that is
+signed, registered, loaded, tested, and removed again.
+
+Run the deployment commands from an elevated PowerShell session because signing trust, registry
+registration, and WSL service restarts affect the host machine.
+
+## Create the Crate
+
+```powershell
+cargo new my-wsl-plugin --lib
+cd my-wsl-plugin
+```
+
+Configure the crate as a Windows DLL and add the framework dependency:
+
+```toml
+[package]
+name = "my-wsl-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+```
+
+Use this minimal `src/lib.rs`:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct Plugin {
+    _context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1(2, 0, 5)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { _context: context })
+    }
+}
+```
+
+Run normal Rust validation first:
+
+```powershell
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt -- --check
+```
+
+Then build the DLL:
+
+```powershell
+cargo build --release
+```
+
+The DLL path uses underscores even when the crate name uses hyphens:
+
+```text
+target\release\my_wsl_plugin.dll
+```
+
+## Sign and Register
+
+The repository contains a development signing helper. Set variables for the plugin you are testing:
+
+```powershell
+$PluginName = "my-wsl-plugin"
+$DllPath = "C:\path\to\my-wsl-plugin\target\release\my_wsl_plugin.dll"
+$RepoPath = "C:\path\to\wslplugins-rs"
+```
+
+Sign the DLL:
+
+```powershell
+& "$RepoPath\sign-plugin.ps1" -PluginPath $DllPath
+```
+
+For local development, you may also trust the generated certificate on the test machine:
+
+```powershell
+& "$RepoPath\sign-plugin.ps1" -PluginPath $DllPath -Trust
+```
+
+Register the signed DLL:
+
+```powershell
+Set-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Value $DllPath `
+    -Force
+```
+
+Restart WSL and trigger plugin loading:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+wsl.exe echo "plugin load test"
+```
+
+## Verify and Clean Up
+
+Check that the registry value points to the DLL you built:
+
+```powershell
+Get-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName
+```
+
+If WSL reports a plugin load error, use the troubleshooting chapter before changing code.
+
+When finished testing, unregister the plugin and restart WSL:
+
+```powershell
+Remove-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name $PluginName `
+    -Force
+
+Stop-Service -Name "wslservice" -Force
+```
+
+Next: read [Your First Plugin](./first-plugin.md) to add hooks and behavior.

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -25,7 +25,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+wslplugins-rs = { version = "0.1.0-beta.4", features = ["macro"] }
 ```
 
 Use this minimal `src/lib.rs`:

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -38,7 +38,7 @@ pub(crate) struct Plugin {
     _context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         Ok(Self { _context: context })

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -1,0 +1,66 @@
+# Testing
+
+Testing a WSL plugin happens at two levels: ordinary Rust validation for your crate and host
+validation on Windows after the DLL is signed and registered.
+
+## Rust Validation
+
+Run normal Rust checks while developing your plugin:
+
+```powershell
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt -- --check
+```
+
+Unit tests are useful for your own parsing, policy, configuration, and decision logic. Keep direct
+WSL service behavior behind small boundaries so most of the plugin can be tested without loading a
+DLL into the host service.
+
+## Hook-Oriented Tests
+
+Where possible, separate hook code from business logic:
+
+```rust
+fn should_block_distribution(name: &str) -> bool {
+    name.eq_ignore_ascii_case("blocked")
+}
+```
+
+Then call that logic from `on_distribution_registered`, `on_vm_started`, or whichever hook applies.
+This keeps hook implementations small and makes failures easier to reproduce in ordinary Rust tests.
+
+## Windows Host Validation
+
+Use host validation when you need to prove the DLL works with the real WSL service:
+
+1. Build the target example in release mode.
+2. Sign the DLL.
+3. Register the DLL under the WSL plugins registry key.
+4. Restart the WSL service.
+5. Run a WSL command that triggers the plugin.
+6. Inspect plugin output and any expected side effects.
+
+For the minimal example, the observable output is written to `C:\wsl-plugin-demo.txt`.
+
+For your own plugin, choose an observable result that fits the behavior: a log file, an allowed or
+blocked operation, a command output, or another side effect that confirms the expected hook ran.
+
+Use commands that trigger the hook you are validating:
+
+```powershell
+wsl.exe echo "vm startup test"
+wsl.exe -d Ubuntu -- echo "distribution startup test"
+```
+
+For more WSL command examples, see Microsoft's
+[basic WSL commands](https://learn.microsoft.com/en-us/windows/wsl/basic-commands) documentation.
+
+After rebuilding or changing the registry value, restart the WSL service before testing again:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+```
+
+If the plugin does not load or the expected hook does not run, use the
+[Troubleshooting](./troubleshooting.md) chapter before changing the plugin code.

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -1,0 +1,148 @@
+# Troubleshooting
+
+This page maps common WSL plugin failures to the first checks to run. Start with the registered DLL
+path, signature, WSL service restart, and API version before changing plugin logic.
+
+## Plugin Does Not Load
+
+Error:
+
+```text
+Wsl/Service/CreateInstance/CreateVm/Plugin/ERROR_MOD_NOT_FOUND
+```
+
+Likely causes:
+
+- the registry value points to the wrong path;
+- the DLL was rebuilt under a different crate name;
+- a native dependency of the DLL is missing.
+
+Check the registered path:
+
+```powershell
+Get-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins"
+```
+
+Check that the DLL exists:
+
+```powershell
+Test-Path "C:\path\to\plugin.dll"
+```
+
+Remember that Cargo converts hyphens to underscores for library artifact names. A crate named
+`my-wsl-plugin` produces `my_wsl_plugin.dll`.
+
+## Signature Is Rejected
+
+Error:
+
+```text
+Wsl/Service/CreateInstance/CreateVm/Plugin/TRUST_E_NOSIGNATURE
+```
+
+Likely causes:
+
+- the DLL is unsigned;
+- the signing certificate is not trusted by the machine;
+- Windows test signing is required for the development scenario.
+
+Check the signature:
+
+```powershell
+Get-AuthenticodeSignature "C:\path\to\plugin.dll"
+```
+
+For local development, sign with a test certificate and trust it on the test machine. If WSL still
+rejects the DLL, Microsoft documentation may require test signing:
+
+```powershell
+Bcdedit.exe -set TESTSIGNING ON
+```
+
+A reboot may be required. If Secure Boot blocks the setting, decide whether disabling Secure Boot is
+acceptable for that machine before continuing.
+
+## Hook Does Not Run
+
+Likely causes:
+
+- the DLL was registered after WSL had already loaded plugins;
+- the event you are testing does not trigger the hook you implemented;
+- the hook requires a newer WSL plugin API version than the host provides.
+
+Restart the service after registration or rebuilds:
+
+```powershell
+Stop-Service -Name "wslservice" -Force
+```
+
+Then run a command that creates the lifecycle event you need. For VM startup hooks, a simple command
+is enough:
+
+```powershell
+wsl.exe echo "test"
+```
+
+For distribution startup hooks, target a specific distribution:
+
+```powershell
+wsl.exe -d Ubuntu -- echo "test"
+```
+
+## WSL Reports Plugin Error
+
+Errors under these paths usually mean the plugin returned an error:
+
+```text
+Wsl/Service/CreateInstance/CreateVm/Plugin/*
+Wsl/Service/CreateInstance/Plugin/*
+```
+
+Check which hook can fail in that path:
+
+- `CreateVm/Plugin/*`: entry point initialization or `on_vm_started`;
+- `CreateInstance/Plugin/*`: `on_distribution_started`.
+
+Use `PluginResult` with a message for user-facing policy failures. Use ordinary `Result` handling
+for I/O, parsing, and WSL API calls instead of panicking. See
+[Error Handling](./error-handling.md) for the difference between plugin diagnostics and plain
+Windows errors.
+
+## Runtime API Is Too Old
+
+If the plugin requests a newer API version than WSL provides, initialization fails with
+`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+
+Use the version in `#[wsl_plugin_v1(major, minor, revision)]` as the minimum API version for the
+plugin as a whole. Keep it as low as practical, and use runtime `Result` checks for optional fields
+or optional behavior.
+
+Common version-sensitive features include:
+
+| Feature | Minimum API version |
+| --- | --- |
+| `init_pid()` | `2.0.5` |
+| Distribution registration hooks | `2.1.2` |
+| `ExecuteBinaryInDistribution` | `2.1.2` |
+| `flavor()` and `version()` | `2.4.4` |
+
+## Cleanup After a Bad Deployment
+
+Remove the registry value and restart WSL:
+
+```powershell
+Remove-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins" `
+    -Name "my-wsl-plugin" `
+    -Force
+
+Stop-Service -Name "wslservice" -Force
+```
+
+If WSL still behaves unexpectedly, verify that no other plugin values remain under the plugins key:
+
+```powershell
+Get-ItemProperty `
+    -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\Plugins"
+```

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -111,21 +111,13 @@ Windows errors.
 
 ## Runtime API Is Too Old
 
-If the plugin requests a newer API version than WSL provides, initialization fails with
-`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+If the plugin requests a newer API version or capability than WSL provides, initialization fails
+with `WSL_E_PLUGIN_REQUIRES_UPDATE`.
 
-Use the version in `#[wsl_plugin_v1(major, minor, revision)]` as the minimum API version for the
-plugin as a whole. Keep it as low as practical, and use runtime `Result` checks for optional fields
-or optional behavior.
-
-Common version-sensitive features include:
-
-| Feature | Minimum API version |
-| --- | --- |
-| `init_pid()` | `2.0.5` |
-| Distribution registration hooks | `2.1.2` |
-| `ExecuteBinaryInDistribution` | `2.1.2` |
-| `flavor()` and `version()` | `2.4.4` |
+Use `#[wsl_plugin_v1(...)]` for requirements that are mandatory for the plugin as a whole. Keep the
+requirement as low as practical, and use runtime `Result` checks for optional fields or optional
+behavior. The capability list and minimum API versions are centralized in
+[Version Capabilities](./version-capabilities.md).
 
 ## Cleanup After a Bad Deployment
 

--- a/book/src/version-capabilities.md
+++ b/book/src/version-capabilities.md
@@ -1,0 +1,147 @@
+# Version Capabilities
+
+WSL Plugin API features are introduced over time. `wslplugins-rs` models those feature gates with
+`WSLVersionCapability`, so plugin code can name the API feature it depends on instead of hard-coding
+the version number everywhere.
+
+Use capabilities when the crate exposes one for the feature you need. Use an explicit version only
+when the plugin depends on an API surface that does not yet have a named capability. The capability
+matrix below is the canonical list for this book; other chapters link here instead of repeating it.
+
+## Capability Reference
+
+| Capability | Enables | Minimum API version |
+| --- | --- | --- |
+| <a id="distribution-init-pid"></a>`DistributionInitPid` | `WSLDistributionInformation::init_pid()` | `2.0.5` |
+| <a id="distribution-registered-hook"></a>`DistributionRegisteredHook` | `on_distribution_registered` hook wiring | `2.1.2` |
+| <a id="distribution-unregistered-hook"></a>`DistributionUnregisteredHook` | `on_distribution_unregistered` hook wiring | `2.1.2` |
+| <a id="execute-binary-in-distribution"></a>`ExecuteBinaryInDistribution` | command execution inside a user distribution | `2.1.2` |
+| <a id="distribution-flavor"></a>`DistributionFlavor` | `CoreWSLDistributionInformation::flavor()` | `2.4.4` |
+| <a id="distribution-version"></a>`DistributionVersion` | `CoreWSLDistributionInformation::version()` | `2.4.4` |
+
+For command execution details, see [Command Execution](./command-execution.md). For the lifecycle
+and registration events exposed by `WSLPluginV1`, see [WSL Plugin Model](./wsl-plugin-model.md).
+
+## Plugin Requirements
+
+The `#[wsl_plugin_v1]` macro checks the plugin-wide API requirement before `try_new` runs:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+pub(crate) struct Plugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1]
+impl WSLPluginV1 for Plugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+}
+```
+
+No argument means the plugin only requires the base entry point. If the whole plugin needs a known
+minimum API version, pass that version explicitly:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(2, 1)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+The revision component is optional and defaults to `0`:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+When a named capability exists, prefer it:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(WSLVersionCapability::ExecuteBinaryInDistribution)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+Capabilities can be combined with `|`. The macro uses the highest minimum API version required by
+the listed capabilities:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+# pub(crate) struct Plugin;
+#[wsl_plugin_v1(
+    WSLVersionCapability::DistributionRegisteredHook
+        | WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+```
+
+If the host WSL Plugin API is too old for the plugin-wide requirement, initialization fails with
+`WSL_E_PLUGIN_REQUIRES_UPDATE`. WSL does not call `try_new`, and the hook table is not registered
+for that plugin.
+
+## Runtime Checks
+
+Plugin-wide requirements are the right choice when the plugin cannot behave correctly without the
+feature. Optional features should stay as runtime `Result` checks:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> {
+    distribution
+        .flavor()
+        .ok()
+        .flatten()
+        .map(|value| value.to_string_lossy().into_owned())
+}
+```
+
+The same rule applies to command execution. If distribution-scoped command execution is central to
+the plugin, declare
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`) in `#[wsl_plugin_v1(...)]`.
+If it is optional, handle the API error returned by `execute()`.
+
+## Inspecting Versions
+
+`WSLVersionCapability::required_version()` returns the minimum API version for one capability.
+`WSLVersion::supports(capability)` checks whether a runtime API version supports a capability, and
+`WSLVersion::capabilities()` iterates over the capabilities supported by that version.
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::{WSLVersion, WSLVersionCapability};
+
+let version = WSLVersion::new(2, 1, 2);
+
+assert!(version.supports(WSLVersionCapability::ExecuteBinaryInDistribution));
+```

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -32,11 +32,12 @@ The API table contains:
 - `MountFolder`, for creating a Plan 9 mount between Windows and Linux;
 - `ExecuteBinary`, for running a program in the root namespace of the WSL2 VM;
 - `PluginError`, for passing a user-facing failure message back to WSL;
-- `ExecuteBinaryInDistribution`, introduced in API version `2.1.2`, for running a program inside a
-  user distribution.
+- `ExecuteBinaryInDistribution`, for running a program inside a user distribution when the host API
+  supports that capability.
 
 The hook table contains VM lifecycle hooks, distribution lifecycle hooks, and distribution
-registration hooks. The registration hooks were introduced in API version `2.1.2`.
+registration hooks. Registration and unregistration hooks are version-gated capabilities; see
+[Version Capabilities](./version-capabilities.md).
 
 ## Plugin State
 
@@ -71,40 +72,43 @@ The public crate provides typed wrappers for common WSL concepts:
 - `WSLVmCreationSettings`: VM creation settings.
 - `SessionID`, `DistributionID`, and `UserDistributionID`: typed identifiers.
 - `WSLVersion`: parsed WSL version values.
+- `WSLVersionCapability`: named feature gates for version-sensitive API surface.
 
 Prefer these wrappers over raw FFI types in plugin code. Raw access is available behind the `sys`
 feature for cases where a wrapper does not yet expose the needed API.
 
 Online and offline distribution wrappers both implement `CoreWSLDistributionInformation`. That gives
 common access to the distribution ID, name, optional package family name, flavor, and version. The
-crate checks the runtime API version for fields that were added later: `init_pid()` requires
-`2.0.5`, and `flavor()` / `version()` require `2.4.4`.
+crate checks the runtime API capability for fields that were added later. The capability names and
+minimum versions are listed in [Version Capabilities](./version-capabilities.md).
 
 ## Versioned Hooks
 
-Some hooks are only available in newer WSL plugin API versions. For example, distribution
-registration hooks are documented in this crate as introduced in API version `2.1.2`.
+Some hooks are only available in newer WSL plugin API versions. Distribution registration and
+unregistration are represented by
+[`WSLVersionCapability::DistributionRegisteredHook`](./version-capabilities.md#distribution-registered-hook)
+(`2.1.2`) and
+[`WSLVersionCapability::DistributionUnregisteredHook`](./version-capabilities.md#distribution-unregistered-hook)
+(`2.1.2`).
 
-Choose the version passed to `#[wsl_plugin_v1(...)]` according to the hooks and API calls your
-plugin uses. A plugin that only handles basic VM lifecycle events can target an older version than a
-plugin that observes distribution registration.
+Choose the requirement passed to `#[wsl_plugin_v1(...)]` according to the hooks and API calls that
+are mandatory for the plugin. A plugin that only handles basic VM lifecycle events can use
+`#[wsl_plugin_v1]`. A plugin whose core behavior depends on registration events should declare the
+matching capability.
 
-The macro accepts `major, minor` or `major, minor, revision`. If the revision is omitted, it is
-treated as `0`.
-
-If WSL offers an older API version than the one requested by the plugin macro, initialization fails
-with `WSL_E_PLUGIN_REQUIRES_UPDATE`. This is preferable to registering callbacks that rely on fields
-or function pointers the host does not provide.
+If WSL offers an older API version than the requirement requested by the plugin macro,
+initialization fails with `WSL_E_PLUGIN_REQUIRES_UPDATE`. This is preferable when the plugin cannot
+operate correctly without that hook or API call.
 
 ## Version Checks
 
 `wslplugins-rs` uses two complementary version checks.
 
-The first check happens when WSL loads the DLL. The version passed to
-`#[wsl_plugin_v1(...)]` is the minimum API version required by the plugin as a whole. During entry
-point initialization, the generated code compares that requirement with `context.api.version()`. If
-the runtime API is too old, plugin creation stops and WSL receives
-`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+The first check happens when WSL loads the DLL. The requirement passed to `#[wsl_plugin_v1(...)]`
+is the minimum API support required by the plugin as a whole. It can be omitted, expressed as an
+explicit version, or expressed as one or more capabilities. During entry point initialization, the
+generated code compares that requirement with `context.api.version()`. If the runtime API is too
+old, plugin creation stops and WSL receives `WSL_E_PLUGIN_REQUIRES_UPDATE`.
 
 That means WSL does not call `try_new` and the hook table is not registered for that plugin. A hook
 that requires a newer API version will therefore never be called if you declare that version in the
@@ -113,8 +117,7 @@ plugin's behavior.
 
 Hook availability is decided when the plugin is registered with WSL, not lazily when an event
 happens. If the current WSL plugin API version does not provide a hook slot, the method associated
-with that event is never called. For example, on a runtime older than `2.1.2`, distribution
-registration and unregistration notifications are not available, so
+with that event is never called. For example, without the distribution registration capabilities,
 `on_distribution_registered` and `on_distribution_unregistered` cannot run.
 
 The second check happens at runtime on individual APIs or fields. Some wrappers return a `Result`
@@ -135,9 +138,9 @@ fn describe_distribution(distribution: &WSLDistributionInformation) -> PluginRes
 
 If the runtime API is too old for `init_pid()`, the call returns a `RequiresUpdate` error that maps
 to `WSL_E_PLUGIN_REQUIRES_UPDATE`. The same pattern is used by distribution-scoped command
-execution: `ExecuteBinaryInDistribution` requires API version `2.1.2`, so
-`with_distribution_id(DistributionID::User(...)).execute()` can return an API error on an older
-runtime.
+execution: `with_distribution_id(DistributionID::User(...)).execute()` requires
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`) and can return an API error on an older runtime.
 
 Use runtime `Result` checks when the feature is optional:
 
@@ -156,8 +159,11 @@ fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> 
 
 Use the macro version requirement when the plugin cannot behave correctly without the newer hook,
 field, or API call. For example, a plugin whose main purpose is to run commands inside a specific
-user distribution should require at least `2.1.2`; a plugin that only uses `flavor()` as a nicer log
-detail can keep a lower macro version and treat that field as optional.
+user distribution should require
+[`WSLVersionCapability::ExecuteBinaryInDistribution`](./version-capabilities.md#execute-binary-in-distribution)
+(`2.1.2`); a plugin that only uses `flavor()` as a nicer log detail can keep a lower macro
+requirement and treat that field as optional. See [Version Capabilities](./version-capabilities.md)
+for the full capability list.
 
 ## Hook Failure Semantics
 

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -1,0 +1,179 @@
+# WSL Plugin Model
+
+WSL plugins are native DLLs loaded by the WSL service. The WSL plugin API calls exported functions
+from the DLL and sends synchronous notifications for lifecycle events.
+
+`wslplugins-rs` turns that model into a Rust trait:
+
+- `try_new` creates the plugin state.
+- `on_vm_started` runs after a VM starts.
+- `on_vm_stopping` runs before a VM stops.
+- `on_distribution_started` runs after a distribution starts.
+- `on_distribution_stopping` runs before a distribution stops.
+- `on_distribution_registered` runs when a distribution is registered.
+- `on_distribution_unregistered` runs when a distribution is unregistered.
+
+The default hook implementations do nothing and return success, so a plugin only implements the
+events it needs.
+
+## What WSL Loads
+
+At the ABI level, a plugin exposes the `WSLPluginAPIV1_EntryPoint` entry point. WSL passes that
+entry point a `WSLPluginAPIV1` table and expects the plugin to fill a `WSLPluginHooksV1` table with
+the callbacks it wants to handle.
+
+The `#[wsl_plugin_v1(...)]` macro generates this entry point and hook table wiring for an
+implementation of `WSLPluginV1`. Most plugin crates should use the macro instead of writing the
+entry point manually.
+
+The API table contains:
+
+- the WSL plugin API version currently offered by the host;
+- `MountFolder`, for creating a Plan 9 mount between Windows and Linux;
+- `ExecuteBinary`, for running a program in the root namespace of the WSL2 VM;
+- `PluginError`, for passing a user-facing failure message back to WSL;
+- `ExecuteBinaryInDistribution`, introduced in API version `2.1.2`, for running a program inside a
+  user distribution.
+
+The hook table contains VM lifecycle hooks, distribution lifecycle hooks, and distribution
+registration hooks. The registration hooks were introduced in API version `2.1.2`.
+
+## Plugin State
+
+The plugin type owns state that must live for the loaded plugin lifetime. The WSL context gives
+access to the API wrapper:
+
+```rust
+# extern crate wslplugins_rs;
+# use wslplugins_rs::prelude::*;
+pub(crate) struct Plugin {
+    context: &'static WSLContext,
+}
+```
+
+The trait requires `Sync` because the host may call plugin hooks from service-owned execution paths.
+Shared state should use synchronization primitives that are appropriate for service code and should
+avoid long blocking critical sections.
+
+The raw WSL structs passed to hooks are borrowed from WSL. The Microsoft header documents those
+pointers as valid only while the hook call is in progress. `wslplugins-rs` exposes typed wrapper
+references for those values, but the same lifetime rule still matters: copy out the data you need if
+it must outlive the hook.
+
+## API Wrappers
+
+The public crate provides typed wrappers for common WSL concepts:
+
+- `WSLContext`: plugin context and access to `ApiV1`.
+- `WSLSessionInformation`: current WSL session metadata.
+- `WSLDistributionInformation`: online distribution metadata.
+- `WSLOfflineDistributionInformation`: offline distribution metadata used by registration hooks.
+- `WSLVmCreationSettings`: VM creation settings.
+- `SessionID`, `DistributionID`, and `UserDistributionID`: typed identifiers.
+- `WSLVersion`: parsed WSL version values.
+
+Prefer these wrappers over raw FFI types in plugin code. Raw access is available behind the `sys`
+feature for cases where a wrapper does not yet expose the needed API.
+
+Online and offline distribution wrappers both implement `CoreWSLDistributionInformation`. That gives
+common access to the distribution ID, name, optional package family name, flavor, and version. The
+crate checks the runtime API version for fields that were added later: `init_pid()` requires
+`2.0.5`, and `flavor()` / `version()` require `2.4.4`.
+
+## Versioned Hooks
+
+Some hooks are only available in newer WSL plugin API versions. For example, distribution
+registration hooks are documented in this crate as introduced in API version `2.1.2`.
+
+Choose the version passed to `#[wsl_plugin_v1(...)]` according to the hooks and API calls your
+plugin uses. A plugin that only handles basic VM lifecycle events can target an older version than a
+plugin that observes distribution registration.
+
+The macro accepts `major, minor` or `major, minor, revision`. If the revision is omitted, it is
+treated as `0`.
+
+If WSL offers an older API version than the one requested by the plugin macro, initialization fails
+with `WSL_E_PLUGIN_REQUIRES_UPDATE`. This is preferable to registering callbacks that rely on fields
+or function pointers the host does not provide.
+
+## Version Checks
+
+`wslplugins-rs` uses two complementary version checks.
+
+The first check happens when WSL loads the DLL. The version passed to
+`#[wsl_plugin_v1(...)]` is the minimum API version required by the plugin as a whole. During entry
+point initialization, the generated code compares that requirement with `context.api.version()`. If
+the runtime API is too old, plugin creation stops and WSL receives
+`WSL_E_PLUGIN_REQUIRES_UPDATE`.
+
+That means WSL does not call `try_new` and the hook table is not registered for that plugin. A hook
+that requires a newer API version will therefore never be called if you declare that version in the
+macro and the host runtime is older. This is the right choice for features that are central to the
+plugin's behavior.
+
+Hook availability is decided when the plugin is registered with WSL, not lazily when an event
+happens. If the current WSL plugin API version does not provide a hook slot, the method associated
+with that event is never called. For example, on a runtime older than `2.1.2`, distribution
+registration and unregistration notifications are not available, so
+`on_distribution_registered` and `on_distribution_unregistered` cannot run.
+
+The second check happens at runtime on individual APIs or fields. Some wrappers return a `Result`
+instead of silently reading a field that may not exist on the current WSL API version:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+fn describe_distribution(distribution: &WSLDistributionInformation) -> PluginResult<String> {
+    let init_pid = distribution.init_pid()?;
+    Ok(format!(
+        "{} is running with init PID {init_pid}",
+        distribution.name().to_string_lossy()
+    ))
+}
+```
+
+If the runtime API is too old for `init_pid()`, the call returns a `RequiresUpdate` error that maps
+to `WSL_E_PLUGIN_REQUIRES_UPDATE`. The same pattern is used by distribution-scoped command
+execution: `ExecuteBinaryInDistribution` requires API version `2.1.2`, so
+`with_distribution_id(DistributionID::User(...)).execute()` can return an API error on an older
+runtime.
+
+Use runtime `Result` checks when the feature is optional:
+
+```rust
+# extern crate wslplugins_rs;
+use wslplugins_rs::prelude::*;
+
+fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> {
+    distribution
+        .flavor()
+        .ok()
+        .flatten()
+        .map(|value| value.to_string_lossy().into_owned())
+}
+```
+
+Use the macro version requirement when the plugin cannot behave correctly without the newer hook,
+field, or API call. For example, a plugin whose main purpose is to run commands inside a specific
+user distribution should require at least `2.1.2`; a plugin that only uses `flavor()` as a nicer log
+detail can keep a lower macro version and treat that field as optional.
+
+## Hook Failure Semantics
+
+Most hook failures are treated as lifecycle failures by WSL. For example, an error from
+`OnVMStarted` or `OnDistributionStarted` can prevent the VM or distribution from starting.
+
+Distribution registration notifications are different in the current Microsoft header: failures from
+`OnDistributionRegistered` and `OnDistributionUnregistered` do not cause the register or unregister
+operation itself to fail. Use those hooks for observation, cleanup, indexing, or best-effort policy
+work. If you need to block startup, enforce that policy in a startup hook instead.
+
+## External References
+
+- Microsoft WSL plugin documentation:
+  <https://learn.microsoft.com/en-us/windows/wsl/wsl-plugins>
+- Microsoft WSL Plugin API NuGet package:
+  <https://www.nuget.org/packages/Microsoft.WSL.PluginApi>
+- Microsoft WSL plugin sample:
+  <https://github.com/microsoft/wsl-plugin-sample>

--- a/crates/wslplugins-macro-core/Cargo.toml
+++ b/crates/wslplugins-macro-core/Cargo.toml
@@ -14,12 +14,15 @@ syn = { workspace = true, features = ["full", "extra-traits"] }
 quote = { workspace = true }
 "proc-macro2" = { workspace = true }
 heck = "0.5"
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { workspace = true }
 
 [build-dependencies]
 wslpluginapi-sys = { workspace = true, features = ["hooks-field-names"] }
 quote = "1"
 struct-field-names-as-array = "0.3"
+
+[dev-dependencies]
+proptest = "1.9.0"
 
 [lints]
 workspace = true

--- a/crates/wslplugins-macro-core/src/generator/hook_field_mapping.rs
+++ b/crates/wslplugins-macro-core/src/generator/hook_field_mapping.rs
@@ -10,7 +10,7 @@ use syn::{parse_str, Ident, Lifetime, Result, Type};
 
 // Main function to generate the complete TokenStream for the plugin
 pub fn generate(imp: &ParsedImpl, version: &RequiredVersion) -> Result<TokenStream> {
-    let entry_point: TokenStream = generate_entry_point(imp, version)?;
+    let entry_point = generate_entry_point(imp, version)?;
     let hooks_funcs = generate_hook_fns(imp.hooks.as_ref())?;
     Ok(quote! {
         #entry_point
@@ -68,17 +68,34 @@ fn hook_field_mapping(hooks_struct_name: &Ident, hook: Hooks) -> Result<TokenStr
         #hooks_struct_name.#field = Some(#func);
     };
     let result = match hook {
-        Hooks::OnDistributionRegistered | Hooks::OnDistributionUnregistered => {
-            let required_version = "2.1.2";
+        Hooks::OnDistributionRegistered => {
+            let capability =
+                quote!(::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook);
             quote! {
-                if current_version >= ::wslplugins_rs::WSLVersion::new(2, 1, 2) {
+                if current_version.supports(#capability) {
                     #base
                 } else {
                     ::wslplugins_rs::__private::debug!(
                         "Hook {} not applied due to insufficient version (found: {}, required: {})",
                         #field_str,
                         current_version,
-                        #required_version
+                        #capability.required_version()
+                    );
+                }
+            }
+        }
+        Hooks::OnDistributionUnregistered => {
+            let capability =
+                quote!(::wslplugins_rs::WSLVersionCapability::DistributionUnregisteredHook);
+            quote! {
+                if current_version.supports(#capability) {
+                    #base
+                } else {
+                    ::wslplugins_rs::__private::debug!(
+                        "Hook {} not applied due to insufficient version (found: {}, required: {})",
+                        #field_str,
+                        current_version,
+                        #capability.required_version()
                     );
                 }
             }
@@ -102,11 +119,18 @@ fn generate_entry_point(imp: &ParsedImpl, version: &RequiredVersion) -> Result<T
         })
         .unwrap_or_default();
     let hook_set = prepare_hooks(&hooks_ref_name, &imp.hooks)?;
-    let RequiredVersion {
-        major,
-        minor,
-        revision,
-    } = version;
+    let create_plugin = match version {
+        RequiredVersion::Version {
+            major,
+            minor,
+            revision,
+        } => quote! {
+            ::wslplugins_rs::plugin::create_plugin_with_required_version(api, #major, #minor, #revision)?
+        },
+        RequiredVersion::Capabilities(capabilities) => quote! {
+            ::wslplugins_rs::plugin::create_plugin_with_required_capabilities(api, [#(#capabilities),*])?
+        },
+    };
 
     Ok(quote! {
         static PLUGIN: ::std::sync::OnceLock<#static_plugin_type> = ::std::sync::OnceLock::new();
@@ -126,7 +150,7 @@ fn generate_entry_point(imp: &ParsedImpl, version: &RequiredVersion) -> Result<T
             api: &'static ::wslplugins_rs::sys::WSLPluginAPIV1,
             hooks_ref: &mut ::wslplugins_rs::sys::WSLPluginHooksV1,
         ) -> ::wslplugins_rs::windows_core::Result<()> {
-            let plugin: #static_plugin_type = ::wslplugins_rs::plugin::create_plugin_with_required_version(api, #major, #minor, #revision)?;
+            let plugin: #static_plugin_type = #create_plugin;
             #current_version
             #(#hook_set)*
             PLUGIN.set(plugin).map_err(|_| ::wslplugins_rs::windows_core::Error::from(::wslplugins_rs::windows_core::HRESULT(::wslplugins_rs::sys::windows_sys::Win32::Foundation::E_ABORT)))
@@ -180,18 +204,19 @@ mod tests {
             hook_field_mapping(&hooks_struct_name, hook);
         assert_eq!(
             result.unwrap().to_string(),
-            quote!(
-                if current_version >= ::wslplugins_rs::WSLVersion::new(2, 1, 2) {
-                    hooks_struct.OnDistributionRegistered = Some(on_distribution_registered);
-                } else {
-                    ::wslplugins_rs::__private::debug!(
-                        "Hook {} not applied due to insufficient version (found: {}, required: {})",
-                        "OnDistributionRegistered",
-                        current_version,
-                        "2.1.2"
-                    );
-                }
-            )
+            quote!(if current_version
+                .supports(::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook)
+            {
+                hooks_struct.OnDistributionRegistered = Some(on_distribution_registered);
+            } else {
+                ::wslplugins_rs::__private::debug!(
+                    "Hook {} not applied due to insufficient version (found: {}, required: {})",
+                    "OnDistributionRegistered",
+                    current_version,
+                    ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook
+                        .required_version()
+                );
+            })
             .to_string()
         );
     }

--- a/crates/wslplugins-macro-core/src/parser/required_version.rs
+++ b/crates/wslplugins-macro-core/src/parser/required_version.rs
@@ -1,18 +1,47 @@
 use syn::parse::{Parse, ParseStream};
-use syn::LitInt;
+use syn::{ExprPath, LitInt};
 use syn::{Result, Token};
 
 use crate::acc_syn_result;
 
 #[derive(Debug)]
-
-pub struct RequiredVersion {
-    pub major: u32,
-    pub minor: u32,
-    pub revision: u32,
+pub enum RequiredVersion {
+    Version {
+        major: u32,
+        minor: u32,
+        revision: u32,
+    },
+    Capabilities(Vec<ExprPath>),
 }
+
+impl Default for RequiredVersion {
+    fn default() -> Self {
+        Self::Version {
+            major: 0,
+            minor: 0,
+            revision: 0,
+        }
+    }
+}
+
 impl Parse for RequiredVersion {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
+        if input.is_empty() {
+            return Ok(Self::default());
+        }
+
+        if !input.peek(LitInt) {
+            let mut capabilities = vec![input.parse::<ExprPath>()?];
+            while input.peek(Token![|]) {
+                input.parse::<Token![|]>()?;
+                capabilities.push(input.parse::<ExprPath>()?);
+            }
+            if input.is_empty() {
+                return Ok(Self::Capabilities(capabilities));
+            }
+            return Err(input.error("unexpected additional tokens after capabilities"));
+        }
+
         // Result of parsing the major version to u32
         let major_lit = input.parse::<LitInt>()?;
         // Result of parsing the coma version to u32
@@ -35,7 +64,7 @@ impl Parse for RequiredVersion {
         let minor_result = minor_lit.base10_parse::<u32>();
         let revision_result = revision_lit.map_or(Ok(0), |lit| lit.base10_parse::<u32>());
         acc_syn_result!(major_result, minor_result, revision_result).map(
-            |(major, minor, revision)| Self {
+            |(major, minor, revision)| Self::Version {
                 major,
                 minor,
                 revision,
@@ -48,17 +77,27 @@ impl Parse for RequiredVersion {
 #[allow(clippy::unwrap_used, clippy::expect_used, reason = "Test code")]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use quote::quote;
     use syn::parse2;
 
     #[test]
+    #[allow(clippy::panic)]
     fn test_parse_valid_version_with_revision() {
         let version_tokens = quote! { 1, 2, 3 };
         let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
-
-        assert_eq!(parsed_version.major, 1);
-        assert_eq!(parsed_version.minor, 2);
-        assert_eq!(parsed_version.revision, 3);
+        match parsed_version {
+            RequiredVersion::Version {
+                major,
+                minor,
+                revision,
+            } => {
+                assert_eq!(major, 1);
+                assert_eq!(minor, 2);
+                assert_eq!(revision, 3);
+            }
+            RequiredVersion::Capabilities(_) => panic!("expected explicit version"),
+        }
     }
 
     #[test]
@@ -66,9 +105,79 @@ mod tests {
         let version_tokens = quote! { 1, 2 };
         let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
 
-        assert_eq!(parsed_version.major, 1);
-        assert_eq!(parsed_version.minor, 2);
-        assert_eq!(parsed_version.revision, 0);
+        match parsed_version {
+            RequiredVersion::Version {
+                major,
+                minor,
+                revision,
+            } => {
+                assert_eq!(major, 1);
+                assert_eq!(minor, 2);
+                assert_eq!(revision, 0);
+            }
+            RequiredVersion::Capabilities(_) => panic!("expected explicit version"),
+        }
+    }
+
+    #[test]
+    fn test_parse_empty_version_as_minimum_version() {
+        let version_tokens = quote! {};
+        let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
+
+        match parsed_version {
+            RequiredVersion::Version {
+                major,
+                minor,
+                revision,
+            } => {
+                assert_eq!(major, 0);
+                assert_eq!(minor, 0);
+                assert_eq!(revision, 0);
+            }
+            RequiredVersion::Capabilities(_) => panic!("expected minimum version"),
+        }
+    }
+
+    #[test]
+    fn test_parse_valid_capability() {
+        let version_tokens =
+            quote! { ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook };
+        let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
+
+        match parsed_version {
+            RequiredVersion::Version { .. } => panic!("expected capability"),
+            RequiredVersion::Capabilities(capabilities) => {
+                assert_eq!(
+                    quote!(#(#capabilities)|*).to_string(),
+                    quote!(::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook)
+                        .to_string()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_valid_capability_set() {
+        let version_tokens = quote! {
+            ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook
+            | ::wslplugins_rs::WSLVersionCapability::DistributionUnregisteredHook
+        };
+        let parsed_version: RequiredVersion = parse2(version_tokens).unwrap();
+
+        match parsed_version {
+            RequiredVersion::Version { .. } => panic!("expected capability set"),
+            RequiredVersion::Capabilities(capabilities) => {
+                assert_eq!(capabilities.len(), 2);
+                assert_eq!(
+                    quote!(#(#capabilities)|*).to_string(),
+                    quote!(
+                        ::wslplugins_rs::WSLVersionCapability::DistributionRegisteredHook
+                            | ::wslplugins_rs::WSLVersionCapability::DistributionUnregisteredHook
+                    )
+                    .to_string()
+                );
+            }
+        }
     }
 
     #[test]
@@ -109,5 +218,56 @@ mod tests {
             parsed_result.unwrap_err().to_string(),
             "unexpected additional components in version"
         );
+    }
+
+    proptest! {
+        #[test]
+        fn parse_valid_version_with_generated_components(
+            major in any::<u32>(),
+            minor in any::<u32>(),
+            revision in any::<u32>(),
+        ) {
+            let version_tokens = quote! { #major, #minor, #revision };
+            let parsed_version: RequiredVersion = parse2(version_tokens)?;
+
+            match parsed_version {
+                RequiredVersion::Version {
+                    major: parsed_major,
+                    minor: parsed_minor,
+                    revision: parsed_revision,
+                } => {
+                    prop_assert_eq!(parsed_major, major);
+                    prop_assert_eq!(parsed_minor, minor);
+                    prop_assert_eq!(parsed_revision, revision);
+                }
+                RequiredVersion::Capabilities(_) => {
+                    prop_assert!(false, "expected explicit version");
+                }
+            }
+        }
+
+        #[test]
+        fn parse_valid_version_without_generated_revision(
+            major in any::<u32>(),
+            minor in any::<u32>(),
+        ) {
+            let version_tokens = quote! { #major, #minor };
+            let parsed_version: RequiredVersion = parse2(version_tokens)?;
+
+            match parsed_version {
+                RequiredVersion::Version {
+                    major: parsed_major,
+                    minor: parsed_minor,
+                    revision,
+                } => {
+                    prop_assert_eq!(parsed_major, major);
+                    prop_assert_eq!(parsed_minor, minor);
+                    prop_assert_eq!(revision, 0);
+                }
+                RequiredVersion::Capabilities(_) => {
+                    prop_assert!(false, "expected explicit version");
+                }
+            }
+        }
     }
 }

--- a/crates/wslplugins-macro-tests/Cargo.toml
+++ b/crates/wslplugins-macro-tests/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 wslplugins-rs = { path = "../wslplugins-rs", features = [
   "macro",
-], version = "0.1.0-beta.3" }
+], version = "0.1.0-beta.4" }
 wslpluginapi-sys.workspace = true
 
 [dependencies.windows]

--- a/crates/wslplugins-macro-tests/tests/proc-macro-tests.rs
+++ b/crates/wslplugins-macro-tests/tests/proc-macro-tests.rs
@@ -4,6 +4,7 @@ mod test {
     #[test]
     fn test_macro_sucess() {
         let t = TestCases::new();
-        t.pass("tests/ui/success.rs")
+        t.pass("tests/ui/success.rs");
+        t.pass("tests/ui/success_capability.rs");
     }
 }

--- a/crates/wslplugins-macro-tests/tests/ui/success_capability.rs
+++ b/crates/wslplugins-macro-tests/tests/ui/success_capability.rs
@@ -1,0 +1,17 @@
+use windows::core::Result as WinResult;
+use wslplugins_rs::plugin::WSLPluginV1;
+use wslplugins_rs::{wsl_plugin_v1, WSLContext, WSLVersionCapability};
+
+pub(crate) struct Plugin;
+
+#[wsl_plugin_v1(
+    WSLVersionCapability::DistributionRegisteredHook
+        | WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for Plugin {
+    fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self)
+    }
+}
+
+fn main() {}

--- a/crates/wslplugins-macro/Cargo.toml
+++ b/crates/wslplugins-macro/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::windows-apis", "api-bindings", "virtualization"]
 proc-macro = true
 
 [dependencies]
-wslplugins-macro-core = { path = "../wslplugins-macro-core", version = "0.1.0-beta.3"}
+wslplugins-macro-core = { path = "../wslplugins-macro-core", version = "0.1.0-beta.4"}
 syn = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/wslplugins-macro/src/lib.rs
+++ b/crates/wslplugins-macro/src/lib.rs
@@ -3,10 +3,52 @@
 //! Provides procedural macros for WSL plugin development.
 use proc_macro::TokenStream;
 /// Attribute macro for WSL plugin V1.
-/// This macro should be used on impl block of `WSLPluginV1` in order to register the plugin that implement this interface
-/// # Example
-/// ``` rust, ignore
+///
+/// This macro should be used on an `impl WSLPluginV1` block to register a
+/// plugin implementation and generate the WSL Plugin API entry point.
+///
+/// The attribute accepts one of these required version forms:
+///
+/// - `#[wsl_plugin_v1]`, which does not require a specific minimum WSL Plugin
+///   API version beyond the entry point being available.
+/// - `#[wsl_plugin_v1(major, minor)]`, which requires `major.minor.0`.
+/// - `#[wsl_plugin_v1(major, minor, revision)]`, which requires the exact
+///   `major.minor.revision` minimum version.
+/// - `#[wsl_plugin_v1(capability)]` or
+///   `#[wsl_plugin_v1(capability_a | capability_b)]`, which requires the
+///   minimum version for the listed
+///   [`WSLVersionCapability`](https://docs.rs/wslplugins-rs/latest/wslplugins_rs/enum.WSLVersionCapability.html)
+///   value or values.
+///
+/// # Minimum version example
+/// ```rust, ignore
 /// #[wsl_plugin_v1]
+/// impl WSLPluginV1 for MyPlugin {
+///     // Implementation details
+/// }
+/// ```
+///
+/// # Explicit version example
+/// ```rust, ignore
+/// #[wsl_plugin_v1(2, 1, 3)]
+/// impl WSLPluginV1 for MyPlugin {
+///     // Implementation details
+/// }
+/// ```
+///
+/// # Capability example
+///
+/// This example uses
+/// [`WSLVersionCapability::DistributionRegisteredHook`](https://docs.rs/wslplugins-rs/latest/wslplugins_rs/enum.WSLVersionCapability.html#variant.DistributionRegisteredHook)
+/// (`2.1.2`) and
+/// [`WSLVersionCapability::DistributionUnregisteredHook`](https://docs.rs/wslplugins-rs/latest/wslplugins_rs/enum.WSLVersionCapability.html#variant.DistributionUnregisteredHook)
+/// (`2.1.2`).
+///
+/// ```rust, ignore
+/// #[wsl_plugin_v1(
+///     WSLVersionCapability::DistributionRegisteredHook
+///     | WSLVersionCapability::DistributionUnregisteredHook
+/// )]
 /// impl WSLPluginV1 for MyPlugin {
 ///     // Implementation details
 /// }

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -25,6 +25,7 @@ wslpluginapi-sys.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }
 semver = { version = "1", optional = true }
+strum = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { version = "0.1.43", optional = true }
 thiserror = "2.0.7"
 typed-path = ">0.1"
 widestring = { version = "1", features = ["alloc"] }
-wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.3" }
+wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.4" }
 wslpluginapi-sys.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }

--- a/crates/wslplugins-rs/src/api/api_v1.rs
+++ b/crates/wslplugins-rs/src/api/api_v1.rs
@@ -3,7 +3,7 @@ use super::Error;
 use super::{Result, WSLCommand};
 use crate::api::errors::require_update_error::Result as UpReqResult;
 use crate::api::wsl_command::IntoCowUtf8UnixPath;
-use crate::{HasSessionId, SessionID, UserDistributionID, WSLVersion};
+use crate::{HasSessionId, SessionID, UserDistributionID, WSLVersion, WSLVersionCapability};
 use std::ffi::OsStr;
 use std::fmt::{self, Debug};
 use std::mem::MaybeUninit;
@@ -24,7 +24,7 @@ use crate::DistributionID;
 
 use wslpluginapi_sys::WSLPluginAPIV1;
 
-use super::utils::check_required_version_result;
+use super::utils::check_requirement_result;
 
 /// Represents a structured interface for interacting with the `WSLPluginAPIV1` API.
 ///
@@ -182,7 +182,7 @@ impl ApiV1 {
         c_path: &[u8],
         args: &[*const u8],
     ) -> Result<TcpStream> {
-        self.check_required_version(&WSLVersion::new(2, 1, 2))?;
+        self.require_capability(WSLVersionCapability::ExecuteBinaryInDistribution)?;
         let mut socket = MaybeUninit::<WinSocket>::uninit();
         let guid: wslpluginapi_sys::windows_sys::core::GUID = distribution_id.into();
         // SAFETY: Calling ExecuteBinaryInDistribution is safe with agument correctly prepared.
@@ -230,8 +230,8 @@ impl ApiV1 {
         WSLCommand::new(self, session_id, program)
     }
 
-    fn check_required_version(&self, version: &WSLVersion) -> UpReqResult<()> {
-        check_required_version_result(self.version(), version)
+    fn require_capability(&self, capability: WSLVersionCapability) -> UpReqResult<()> {
+        check_requirement_result(self.version(), capability)
     }
 }
 

--- a/crates/wslplugins-rs/src/api/errors.rs
+++ b/crates/wslplugins-rs/src/api/errors.rs
@@ -6,7 +6,7 @@
 
 use thiserror::Error;
 pub mod require_update_error;
-pub use require_update_error::Error as RequireUpdateError;
+pub use require_update_error::{Error as RequireUpdateError, RequirementDefinition};
 use windows_core::{Error as WinError, HRESULT};
 use wslpluginapi_sys::WSL_E_PLUGIN_REQUIRES_UPDATE;
 

--- a/crates/wslplugins-rs/src/api/errors/require_update_error.rs
+++ b/crates/wslplugins-rs/src/api/errors/require_update_error.rs
@@ -5,24 +5,26 @@
 //! with WSL APIs.
 
 use crate::WSLVersion;
+mod requirement_definition;
+pub use requirement_definition::RequirementDefinition;
 use thiserror::Error;
 use windows_core::HRESULT;
 
 /// Represents an error when the current WSL version is unsupported.
 ///
 /// This error is returned when the WSL version being used does not satisfy
-/// the required version for a plugin.
+/// the required version or capabilities for a plugin.
 ///
 /// # Fields
 /// - `current_version`: The current WSL version.
-/// - `required_version`: The required WSL version.
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
-#[error("WSLVersion unsupported: current version {current_version}, required version {required_version}")]
+/// - `requirement`: The version or capabilities required by the operation.
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
+#[error("WSLVersion unsupported: current version {current_version}, required {requirement} (minimum version {})", requirement.version())]
 pub struct Error {
     /// The current version of WSL.
     pub current_version: WSLVersion,
-    /// The required version of WSL.
-    pub required_version: WSLVersion,
+    /// The version or capabilities required by the operation.
+    pub requirement: RequirementDefinition,
 }
 
 impl Error {
@@ -39,7 +41,27 @@ impl Error {
     pub const fn new(current_version: WSLVersion, required_version: WSLVersion) -> Self {
         Self {
             current_version,
-            required_version,
+            requirement: RequirementDefinition::Version(required_version),
+        }
+    }
+
+    /// Creates a new `Error` with the specified current WSL version and requirement.
+    ///
+    /// # Arguments
+    /// - `current_version`: The version currently in use.
+    /// - `requirement`: The version or capabilities required for compatibility.
+    ///
+    /// # Returns
+    /// A new instance of `Error`.
+    #[must_use]
+    #[inline]
+    pub fn from_requirement(
+        current_version: WSLVersion,
+        requirement: impl Into<RequirementDefinition>,
+    ) -> Self {
+        Self {
+            current_version,
+            requirement: requirement.into(),
         }
     }
     pub const WSL_E_PLUGIN_REQUIRES_UPDATE: HRESULT =

--- a/crates/wslplugins-rs/src/api/errors/require_update_error/requirement_definition.rs
+++ b/crates/wslplugins-rs/src/api/errors/require_update_error/requirement_definition.rs
@@ -1,0 +1,178 @@
+use crate::{WSLVersion, WSLVersionCapability};
+use std::collections::HashSet;
+use std::fmt::{self, Display};
+use std::hash::{Hash, Hasher};
+use strum::IntoEnumIterator as _;
+
+/// Defines what WSL Plugin API support is required.
+///
+/// A requirement can be expressed either as an explicit API version or as one
+/// or more named capabilities. Capability requirements are resolved to the
+/// highest minimum version required by the listed capabilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequirementDefinition {
+    /// Requires an explicit WSL Plugin API version.
+    Version(WSLVersion),
+    /// Requires one or more WSL Plugin API capabilities.
+    Capabilities(HashSet<WSLVersionCapability>),
+}
+
+impl RequirementDefinition {
+    /// Returns the minimum WSL Plugin API version required by this definition.
+    #[must_use]
+    #[inline]
+    pub fn version(&self) -> WSLVersion {
+        match self {
+            Self::Version(version) => *version,
+            Self::Capabilities(capabilities) => capabilities
+                .iter()
+                .copied()
+                .map(WSLVersionCapability::required_version)
+                .max()
+                .unwrap_or(WSLVersion::new(0, 0, 0)),
+        }
+    }
+}
+
+impl From<WSLVersion> for RequirementDefinition {
+    #[inline]
+    fn from(value: WSLVersion) -> Self {
+        Self::Version(value)
+    }
+}
+
+impl From<WSLVersionCapability> for RequirementDefinition {
+    #[inline]
+    fn from(value: WSLVersionCapability) -> Self {
+        Self::Capabilities(HashSet::from([value]))
+    }
+}
+
+impl From<HashSet<WSLVersionCapability>> for RequirementDefinition {
+    #[inline]
+    fn from(value: HashSet<WSLVersionCapability>) -> Self {
+        Self::Capabilities(value)
+    }
+}
+
+impl<const N: usize> From<[WSLVersionCapability; N]> for RequirementDefinition {
+    #[inline]
+    fn from(value: [WSLVersionCapability; N]) -> Self {
+        Self::Capabilities(HashSet::from(value))
+    }
+}
+
+impl FromIterator<WSLVersionCapability> for RequirementDefinition {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = WSLVersionCapability>>(iter: T) -> Self {
+        Self::Capabilities(iter.into_iter().collect())
+    }
+}
+
+impl Hash for RequirementDefinition {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Version(version) => {
+                0_u8.hash(state);
+                version.hash(state);
+            }
+            Self::Capabilities(capabilities) => {
+                1_u8.hash(state);
+                for capability in WSLVersionCapability::iter()
+                    .filter(|capability| capabilities.contains(capability))
+                {
+                    capability.hash(state);
+                }
+            }
+        }
+    }
+}
+
+impl Display for RequirementDefinition {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Version(version) => write!(f, "version {version}"),
+            Self::Capabilities(capabilities) => {
+                write!(f, "capabilities ")?;
+                for (index, capability) in WSLVersionCapability::iter()
+                    .filter(|capability| capabilities.contains(capability))
+                    .enumerate()
+                {
+                    if index > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{capability}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use proptest::sample::select;
+
+    fn arb_wsl_version() -> impl Strategy<Value = WSLVersion> {
+        (any::<u32>(), any::<u32>(), any::<u32>())
+            .prop_map(|(major, minor, revision)| WSLVersion::new(major, minor, revision))
+    }
+
+    fn arb_capability() -> impl Strategy<Value = WSLVersionCapability> {
+        select(WSLVersionCapability::iter().collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn version_requirement_returns_explicit_version() {
+        let version = WSLVersion::new(2, 1, 2);
+        let requirement = RequirementDefinition::from(version);
+
+        assert_eq!(requirement.version(), version);
+    }
+
+    #[test]
+    fn capability_requirement_returns_highest_required_version() {
+        let requirement = RequirementDefinition::from([
+            WSLVersionCapability::DistributionInitPid,
+            WSLVersionCapability::DistributionVersion,
+            WSLVersionCapability::DistributionVersion,
+        ]);
+
+        assert_eq!(requirement.version(), WSLVersion::new(2, 4, 4));
+        assert_eq!(
+            requirement,
+            RequirementDefinition::Capabilities(HashSet::from([
+                WSLVersionCapability::DistributionInitPid,
+                WSLVersionCapability::DistributionVersion,
+            ]))
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn version_requirement_always_returns_explicit_version(version in arb_wsl_version()) {
+            let requirement = RequirementDefinition::from(version);
+
+            prop_assert_eq!(requirement.version(), version);
+        }
+
+        #[test]
+        fn capability_requirement_returns_maximum_required_version(
+            capabilities in proptest::collection::hash_set(arb_capability(), 0..=6),
+        ) {
+            let expected = capabilities
+                .iter()
+                .copied()
+                .map(WSLVersionCapability::required_version)
+                .max()
+                .unwrap_or(WSLVersion::new(0, 0, 0));
+            let requirement = RequirementDefinition::from(capabilities);
+
+            prop_assert_eq!(requirement.version(), expected);
+        }
+    }
+}

--- a/crates/wslplugins-rs/src/api/utils.rs
+++ b/crates/wslplugins-rs/src/api/utils.rs
@@ -3,35 +3,54 @@
 //! This module provides utilities to verify that the current WSL version meets the required version for plugin compatibility.
 //! It includes functions to perform version checks and unit tests to ensure correctness.
 
-use super::errors::require_update_error::{Error, Result};
+use super::errors::require_update_error::{Error, RequirementDefinition, Result};
 use crate::cstring_ext::CstringExt;
-use crate::WSLContext;
-use crate::WSLVersion;
+use crate::{WSLContext, WSLVersion, WSLVersionCapability};
 use std::ffi::CString;
 use std::ptr;
 use typed_path::Utf8UnixPath;
 
-pub(crate) fn check_required_version_result(
+pub(crate) const fn check_required_version_result(
     current_version: &WSLVersion,
     required_version: &WSLVersion,
 ) -> Result<()> {
-    if current_version >= required_version {
+    if current_version.is_at_least(*required_version) {
         Ok(())
     } else {
         Err(Error {
             current_version: *current_version,
-            required_version: *required_version,
+            requirement: RequirementDefinition::Version(*required_version),
         })
     }
 }
 
-pub(crate) fn check_required_version_result_from_context(
+pub(crate) fn check_requirement_result(
+    current_version: &WSLVersion,
+    requirement: impl Into<RequirementDefinition>,
+) -> Result<()> {
+    let requirement = requirement.into();
+    match requirement {
+        RequirementDefinition::Version(version) => {
+            check_required_version_result(current_version, &version)
+        }
+        RequirementDefinition::Capabilities(_) => {
+            if current_version.is_at_least(requirement.version()) {
+                Ok(())
+            } else {
+                Err(Error::from_requirement(*current_version, requirement))
+            }
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn check_capability_result_from_context(
     wsl_context: Option<&WSLContext>,
-    required_version: &WSLVersion,
+    capability: WSLVersionCapability,
 ) -> Result<()> {
     wsl_context.map_or(Ok(()), |context| {
         let current_version = context.api.version();
-        check_required_version_result(current_version, required_version)
+        check_requirement_result(current_version, capability)
     })
 }
 #[inline]
@@ -69,27 +88,11 @@ where
 mod tests {
     use super::*;
     use crate::WSLVersion;
+    use proptest::prelude::*;
 
-    /// Tests that `check_required_version_result` returns `Ok` when the current version meets the requirement.
-    #[test]
-    fn test_check_required_version_result_ok() {
-        let current_version = WSLVersion::new(2, 1, 3);
-        let required_version = WSLVersion::new(2, 1, 2);
-
-        let result = check_required_version_result(&current_version, &required_version);
-
-        assert!(result.is_ok());
-    }
-
-    /// Tests that `check_required_version_result` returns `Err` when the current version is insufficient.
-    #[test]
-    fn test_check_required_version_result_error() {
-        let current_version = WSLVersion::new(2, 1, 1);
-        let required_version = WSLVersion::new(2, 1, 2);
-
-        let result = check_required_version_result(&current_version, &required_version);
-
-        assert!(result.is_err());
+    fn arb_wsl_version() -> impl Strategy<Value = WSLVersion> {
+        (any::<u32>(), any::<u32>(), any::<u32>())
+            .prop_map(|(major, minor, revision)| WSLVersion::new(major, minor, revision))
     }
 
     #[test]
@@ -118,5 +121,17 @@ mod tests {
         assert_eq!(argv.len(), 3);
         assert_eq!(argv.iter().take_while(|ptr| !ptr.is_null()).count(), 2);
         assert!(argv.last().is_some_and(|ptr| ptr.is_null()));
+    }
+
+    proptest! {
+        #[test]
+        fn check_required_version_result_matches_version_ordering(
+            current_version in arb_wsl_version(),
+            required_version in arb_wsl_version(),
+        ) {
+            let result = check_required_version_result(&current_version, &required_version);
+
+            prop_assert_eq!(result.is_ok(), current_version.is_at_least(required_version));
+        }
     }
 }

--- a/crates/wslplugins-rs/src/api/utils.rs
+++ b/crates/wslplugins-rs/src/api/utils.rs
@@ -36,11 +36,7 @@ pub(crate) fn check_required_version_result_from_context(
 }
 #[inline]
 pub(super) fn encode_c_path(path: &Utf8UnixPath) -> Vec<u8> {
-    let bytes = path.as_str().as_bytes();
-    let mut out = Vec::with_capacity(bytes.len() + 1);
-    out.extend_from_slice(bytes);
-    out.push(0);
-    out
+    CString::from_str_truncate(path.as_str()).into_bytes_with_nul()
 }
 
 #[allow(clippy::similar_names, reason = "naming is clear")]
@@ -94,5 +90,33 @@ mod tests {
         let result = check_required_version_result(&current_version, &required_version);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn encode_c_path_appends_nul_terminator() {
+        let encoded = encode_c_path("/bin/sh".as_ref());
+
+        assert_eq!(encoded, b"/bin/sh\0");
+    }
+
+    #[test]
+    fn encode_c_path_truncates_at_interior_nul() {
+        let encoded = encode_c_path("/bin\0/sh".as_ref());
+
+        assert_eq!(encoded, b"/bin\0");
+    }
+
+    #[test]
+    fn encode_c_argv_truncates_args_and_null_terminates_argv() {
+        let (c_args, argv) = encode_c_argv(["sh", "arg\0ignored"]);
+        let encoded_args: Vec<_> = c_args
+            .iter()
+            .map(|arg| arg.as_c_str().to_bytes_with_nul())
+            .collect();
+
+        assert_eq!(encoded_args, [b"sh\0".as_slice(), b"arg\0".as_slice()]);
+        assert_eq!(argv.len(), 3);
+        assert_eq!(argv.iter().take_while(|ptr| !ptr.is_null()).count(), 2);
+        assert!(argv.last().is_some_and(|ptr| ptr.is_null()));
     }
 }

--- a/crates/wslplugins-rs/src/api/wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command.rs
@@ -14,7 +14,10 @@ pub use wsl_command_execution::WSLCommandExecution;
 use smallvec::SmallVec;
 
 #[cfg(doc)]
-use crate::{api::Error as ApiError, CoreWSLDistributionInformation, UserDistributionID};
+use crate::{
+    api::Error as ApiError, CoreWSLDistributionInformation, UserDistributionID,
+    WSLVersionCapability,
+};
 mod prepared_wsl_command;
 #[cfg(not(feature = "smallvec"))]
 type ArgVec<'a> = Vec<Cow<'a, str>>;
@@ -37,6 +40,9 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 /// - Arguments are stored as `Cow<'a, str>` to minimize allocations.
 /// - `argv[0]` can be overridden; otherwise it defaults to the program path.
 /// - The execution target can be the system context or a specific distribution.
+/// - When this command targets a user distribution, execution uses the WSL
+///   Plugin API `ExecuteBinaryInDistribution` entry and requires
+///   [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`).
 ///
 /// # Argument semantics
 ///
@@ -91,6 +97,11 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 ///
 /// ## Executing in a user distribution
 ///
+/// In `WSLCommand`, selecting a user distribution target switches execution
+/// from `ExecuteBinary` to `ExecuteBinaryInDistribution`. That command path
+/// requires [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`), which is
+/// checked when the command is executed.
+///
 /// ```no_run
 /// # use wslplugins_rs::{DistributionID, UserDistributionID, SessionID};
 /// # use wslplugins_rs::api::{ApiV1, WSLCommandExecution};
@@ -110,6 +121,9 @@ type ArgVec<'a> = SmallVec<[Cow<'a, str>; 8]>;
 /// - [`WSLCommand::execute`] consumes the command and returns a connected
 ///   [`TcpStream`] to the process stdin/stdout.
 /// - stderr is forwarded to `dmesg` on the Linux side.
+/// - The `ExecuteBinaryInDistribution` capability requirement is specific to
+///   this command execution path (`2.1.2`); it is not a general property of distribution
+///   identifiers.
 /// - This type performs no validation of the Linux path or arguments beyond UTF-8 handling.
 #[doc(alias = "ExecuteBinary")]
 #[doc(alias = "ExecuteBinaryInDistribution")]
@@ -273,6 +287,11 @@ impl<'a> WSLCommand<'a> {
 
     /// Sets the distribution target (builder-style by mutable reference).
     ///
+    /// For `WSLCommand`, a user distribution target is executed through the WSL
+    /// Plugin API `ExecuteBinaryInDistribution` entry. That path requires
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`) and the check is
+    /// performed during [`WSLCommandExecution::execute`].
+    ///
     /// This accepts any value convertible into a [`DistributionID`], including:
     /// - a [`DistributionID`] directly,
     /// - a [`UserDistributionID`],
@@ -287,6 +306,11 @@ impl<'a> WSLCommand<'a> {
     }
 
     /// Sets the distribution target (builder-style by value).
+    ///
+    /// For `WSLCommand`, a user distribution target is executed through the WSL
+    /// Plugin API `ExecuteBinaryInDistribution` entry. That path requires
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`) and the check is
+    /// performed during [`WSLCommandExecution::execute`].
     ///
     /// This accepts any value convertible into a [`DistributionID`], including:
     /// - a [`DistributionID`] directly,

--- a/crates/wslplugins-rs/src/api/wsl_command/prepared_wsl_command.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command/prepared_wsl_command.rs
@@ -3,6 +3,8 @@ use super::WSLCommand;
 use std::ffi::CString;
 use std::net::TcpStream;
 
+#[cfg(doc)]
+use crate::WSLVersionCapability;
 use crate::{
     api::{utils, ApiV1, Result as ApiResult},
     DistributionID, SessionID,
@@ -37,6 +39,10 @@ impl WSLCommandExecution for PreparedWSLCommand<'_> {
     ///
     /// - [`DistributionID::System`] uses `ExecuteBinary`.
     /// - [`DistributionID::User`] uses `ExecuteBinaryInDistribution`.
+    ///
+    /// This is `PreparedWSLCommand` execution behavior. The
+    /// `ExecuteBinaryInDistribution` path requires
+    /// [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`).
     ///
     /// # Errors
     ///

--- a/crates/wslplugins-rs/src/api/wsl_command/wsl_command_execution.rs
+++ b/crates/wslplugins-rs/src/api/wsl_command/wsl_command_execution.rs
@@ -2,7 +2,7 @@ use std::net::TcpStream;
 
 use crate::api::errors::Result as ApiResult;
 #[cfg(doc)]
-use crate::{api::Error as ApiError, DistributionID};
+use crate::{api::Error as ApiError, DistributionID, WSLVersionCapability};
 pub trait WSLCommandExecution {
     /// Executes the command via the underlying WSL Plugin API.
     ///
@@ -16,9 +16,14 @@ pub trait WSLCommandExecution {
     /// - The full argv passed to the API is:
     ///   `argv[0]` + all user-provided args.
     /// - The selected execution method depends on [`DistributionID`].
+    /// - For `WSLCommand` and `PreparedWSLCommand`, a user distribution target
+    ///   uses `ExecuteBinaryInDistribution`, which requires
+    ///   [`WSLVersionCapability::ExecuteBinaryInDistribution`] (`2.1.2`).
     ///
     /// # Errors
     ///
-    /// Returns an [`ApiError`] if the underlying API call fails.
+    /// Returns an [`ApiError`] if the underlying API call fails, including when
+    /// the `ExecuteBinaryInDistribution` command path is selected on an API
+    /// version that does not support it.
     fn execute(&self) -> ApiResult<TcpStream>;
 }

--- a/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
@@ -9,6 +9,8 @@
 //! of a distribution. Implementing this trait allows for seamless integration with systems
 //! that need to handle multiple distributions in a consistent manner.
 
+#[cfg(doc)]
+use crate::WSLVersionCapability;
 use crate::{api::errors::require_update_error::Result, UserDistributionID};
 use std::ffi::OsString;
 
@@ -42,6 +44,8 @@ pub trait CoreWSLDistributionInformation {
 
     /// Retrieves the type of distribution (ubuntu, debian, ...), if available.
     ///
+    /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
+    ///
     /// # Returns
     /// - `Ok(Some(flavor)`: If the distribution has a flavor.
     /// - `Ok(None)`: If the distribution does not have a falvour.
@@ -51,6 +55,8 @@ pub trait CoreWSLDistributionInformation {
     fn flavor(&self) -> Result<Option<OsString>>;
 
     /// Retrieves the version of the distribution, if available
+    ///
+    /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     ///
     /// # Returns
     /// - `Ok(Some(version)`: If the distribution version is available.

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -20,7 +20,8 @@
 //! ### Example
 //!
 //! ```rust
-//! #[cfg(feature = "macro")]
+//! # #[cfg(feature = "macro")]
+//! # mod example {
 //! use wslplugins_rs::prelude::*;
 //! pub(crate) struct MyPlugin {
 //!   context: &'static WSLContext,
@@ -31,6 +32,7 @@
 //!         Ok(MyPlugin { context })
 //!     }
 //! }
+//! # }
 //! ```
 
 /// Provides interfaces for interacting with WSL plugin APIs.

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -14,8 +14,13 @@
 //!
 //! ## Usage
 //!
-//! Use the exposed modules and types to build custom WSL plugins. Conditional features like `macro`
-//! enable procedural macros for simplifying the plugin development process.
+//! Use the exposed modules and types to build custom WSL plugins. The `macro`
+//! feature enables the [`wsl_plugin_v1`] attribute, which generates the WSL
+//! Plugin API entry point and hook wiring for a [`WSLPluginV1`] implementation.
+//!
+//! The macro can be used without arguments for the base API, with an explicit
+//! minimum version, or with one or more [`WSLVersionCapability`] values when the
+//! plugin depends on named API capabilities.
 //!
 //! ### Example
 //!
@@ -26,7 +31,7 @@
 //! pub(crate) struct MyPlugin {
 //!   context: &'static WSLContext,
 //! }
-//! #[wsl_plugin_v1(2, 0, 5)]
+//! #[wsl_plugin_v1]
 //! impl WSLPluginV1 for MyPlugin {
 //!     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
 //!         Ok(MyPlugin { context })
@@ -76,10 +81,14 @@ mod wsl_version;
 pub use api::WSLCommandExecution;
 #[cfg(feature = "semver")]
 pub use wsl_version::SemverConversionError;
+pub use wsl_version::WSLVersionCapability;
 pub use wsl_version::{WSLVersion, WSLVersionParseError};
 
 /// Re-exports procedural macros when the `macro` feature is enabled.
-/// It allow to mark a plugin struct (that implement [`WSLPluginV1`] trait) to be easely integrated to the WSL plugin system without writing manually C code for entry point or hooks.
+///
+/// Use [`wsl_plugin_v1`] on a [`WSLPluginV1`] implementation to generate the
+/// exported WSL Plugin API entry point and hook table setup without writing the
+/// C ABI glue manually.
 #[cfg(feature = "macro")]
 pub use wslplugins_macro::wsl_plugin_v1;
 

--- a/crates/wslplugins-rs/src/plugin/mod.rs
+++ b/crates/wslplugins-rs/src/plugin/mod.rs
@@ -39,4 +39,7 @@ pub use wsl_plugin_v1::WSLPluginV1;
 /// A utility function to create a plugin with a specified required version.
 ///
 /// Refer to [`utils::create_plugin_with_required_version`] for more details.
-pub use utils::create_plugin_with_required_version;
+pub use utils::{
+    create_plugin_with_required_capabilities, create_plugin_with_required_capability,
+    create_plugin_with_required_version,
+};

--- a/crates/wslplugins-rs/src/plugin/utils.rs
+++ b/crates/wslplugins-rs/src/plugin/utils.rs
@@ -3,10 +3,12 @@
 //! This module provides utility functions for creating WSL plugins and handling results,
 //! enabling smooth integration with the WSL Plugin API.
 
+use std::iter::once;
+
 use windows_core::{Error as WinError, Result as WinResult, HRESULT};
 use wslpluginapi_sys::{windows_sys::Win32::Foundation::ERROR_ALREADY_INITIALIZED, WSLPluginAPIV1};
 
-use crate::WSLContext;
+use crate::{WSLContext, WSLVersion, WSLVersionCapability};
 
 #[cfg(doc)]
 use super::Error;
@@ -53,6 +55,43 @@ pub fn create_plugin_with_required_version<T: WSLPluginV1>(
     WSLContext::init(api.as_ref())
         .ok_or_else(|| WinError::from_hresult(HRESULT::from_win32(ERROR_ALREADY_INITIALIZED)))
         .and_then(T::try_new)
+}
+
+/// Creates a WSL plugin instance with a specified required API capability.
+///
+/// # Errors
+/// Returns a Windows error if the API version is insufficient or the plugin is
+/// already initialized.
+#[inline]
+pub fn create_plugin_with_required_capability<T: WSLPluginV1>(
+    api: &'static WSLPluginAPIV1,
+    capability: WSLVersionCapability,
+) -> WinResult<T> {
+    create_plugin_with_required_capabilities(api, once(capability))
+}
+
+/// Creates a WSL plugin instance with a specified set of required API capabilities.
+///
+/// The highest required version among the provided capabilities is selected.
+///
+/// # Errors
+/// Returns a Windows error if the API version is insufficient or the plugin is
+/// already initialized.
+#[inline]
+pub fn create_plugin_with_required_capabilities<T, I>(
+    api: &'static WSLPluginAPIV1,
+    capabilities: I,
+) -> WinResult<T>
+where
+    T: WSLPluginV1,
+    I: IntoIterator<Item = WSLVersionCapability>,
+{
+    let version = capabilities
+        .into_iter()
+        .map(WSLVersionCapability::required_version)
+        .max()
+        .unwrap_or(WSLVersion::new(0, 0, 0));
+    create_plugin_with_required_version(api, version.major(), version.minor(), version.revision())
 }
 
 #[expect(clippy::missing_errors_doc)]

--- a/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
+++ b/crates/wslplugins-rs/src/plugin/wsl_plugin_v1.rs
@@ -7,6 +7,8 @@
 #[cfg(doc)]
 use super::error::Error;
 use super::error::Result;
+#[cfg(doc)]
+use crate::WSLVersionCapability;
 use crate::{
     wsl_distribution_information::WSLDistributionInformation,
     wsl_offline_distribution_information::WSLOfflineDistributionInformation,
@@ -24,19 +26,34 @@ use windows_core::Result as WinResult;
 /// in the WSL plugin system. Each method corresponds to a specific event, such as the start
 /// or stop of a WSL VM or distribution.
 ///
+/// Plugin types are usually registered with the `wsl_plugin_v1` attribute macro
+/// re-exported by `wslplugins-rs` when the `macro` feature is enabled. The macro
+/// generates the exported WSL entry point, initializes [`WSLContext`], creates one
+/// plugin instance through [`WSLPluginV1::try_new`], and wires the trait methods
+/// that are implemented by the plugin.
+///
+/// The macro accepts either no argument, an explicit minimum API version, or one
+/// or more `WSLVersionCapability` values. Use no argument for plugins that only
+/// need the base entry point. Use capabilities when the plugin depends on named
+/// API features such as distribution registration hooks.
+///
 /// # Requirements
 /// - The trait is `Sized` and `Sync`, ensuring safe concurrent usage and instantiation.
 ///
 /// # Example
-/// ```rust
-/// use wslplugins_rs::{plugin::{WSLPluginV1, Result}, WSLContext, WSLSessionInformation, WSLVmCreationSettings};
+/// ```rust,ignore
+/// use wslplugins_rs::prelude::*;
+/// use wslplugins_rs::{WSLSessionInformation, WSLVmCreationSettings};
 /// use wslplugins_rs::windows_core::Result as WinResult;
 ///
-/// struct MyPlugin;
+/// struct MyPlugin {
+///     context: &'static WSLContext,
+/// }
 ///
+/// #[wsl_plugin_v1]
 /// impl WSLPluginV1 for MyPlugin {
 ///     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
-///         Ok(MyPlugin)
+///         Ok(Self { context })
 ///     }
 ///
 ///     fn on_vm_started(
@@ -44,7 +61,7 @@ use windows_core::Result as WinResult;
 ///         session: &WSLSessionInformation,
 ///         user_settings: &WSLVmCreationSettings,
 ///     ) -> Result<()> {
-///         println!("VM started");
+///         let _ = (session, user_settings);
 ///         Ok(())
 ///     }
 /// }
@@ -150,7 +167,8 @@ pub trait WSLPluginV1: Sized + Sync {
     /// # Errors
     /// - `WinError`: If the event handling failed.
     /// # Notes
-    /// - Introduced in API version 2.1.2.
+    /// - This hook is wired only when the host API supports
+    ///   [`WSLVersionCapability::DistributionRegisteredHook`] (`2.1.2`).
     #[expect(
         unused_variables,
         reason = "We are on a treit with default methods that return just Ok(())"
@@ -174,7 +192,8 @@ pub trait WSLPluginV1: Sized + Sync {
     /// - `WinError`: If the event handling failed.
     ///
     /// # Notes
-    /// - Introduced in API version 2.1.2.
+    /// - This hook is wired only when the host API supports
+    ///   [`WSLVersionCapability::DistributionUnregisteredHook`] (`2.1.2`).
     #[expect(
         unused_variables,
         reason = "We are on a treit with default methods that return just 

--- a/crates/wslplugins-rs/src/prelude.rs
+++ b/crates/wslplugins-rs/src/prelude.rs
@@ -19,6 +19,7 @@ pub use crate::plugin::{Error as PluginError, Result as PluginResult, WSLPluginV
 pub use crate::windows_core::{Error as WinError, Result as WinResult};
 #[cfg(feature = "semver")]
 pub use crate::SemverConversionError;
+pub use crate::WSLVersionCapability;
 pub use crate::WSLVersionParseError;
 pub use crate::{
     CoreWSLDistributionInformation, DistributionID, HasSessionId, SessionID, UserDistributionID,

--- a/crates/wslplugins-rs/src/wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_distribution_information.rs
@@ -1,7 +1,7 @@
 //! # WSL Distribution Information
 //!
 //! This module provides a safe abstraction for accessing information about a WSL distribution.
-//! It wraps the `WSLDistributionInformation` structure from the WSL Plugin API and implements
+//! It wraps the [`wslpluginapi_sys::WSLDistributionInformation`] structure from the WSL Plugin API and implements
 //! the [`CoreWSLDistributionInformation`] trait for consistent access to distribution details.
 //!
 //! ## Overview
@@ -9,18 +9,18 @@
 //! - Distribution ID
 //! - Distribution name
 //! - Package family name (if applicable)
-//! - Process ID (PID) of the init process (requires API version 2.0.5 or higher)
+//! - Process ID (PID) of the init process (requires
+//!   [`WSLVersionCapability::DistributionInitPid`] (`2.0.5`) capability)
 //! - PID namespace
 
 #[cfg(doc)]
 use crate::api::errors::require_update_error::Error;
 use crate::api::{
-    errors::require_update_error::Result, utils::check_required_version_result_from_context,
+    errors::require_update_error::Result, utils::check_capability_result_from_context,
 };
 use crate::core_wsl_distribution_information::CoreWSLDistributionInformation;
 use crate::utils::opt_wide_str;
-use crate::WSLVersion;
-use crate::{UserDistributionID, WSLContext};
+use crate::{UserDistributionID, WSLContext, WSLVersionCapability};
 use std::ffi::OsString;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
@@ -67,18 +67,18 @@ impl From<wslpluginapi_sys::WSLDistributionInformation> for WSLDistributionInfor
 impl WSLDistributionInformation {
     /// Retrieves the PID of the init process.
     ///
-    /// This requires API version 2.0.5 or higher. If the current API version does not meet
-    /// the requirement, an error is returned.
+    /// This requires [`WSLVersionCapability::DistributionInitPid`] (`2.0.5`). If the current API
+    /// version does not support the capability, an error is returned.
     ///
     /// # Returns
     /// - `Ok(pid)`: The PID of the init process.
     /// # Errors
-    /// [Error]: If the runtime version version is insufficient.
+    /// [Error]: If the runtime API capability is insufficient.
     #[inline]
     pub fn init_pid(&self) -> Result<u32> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 0, 5),
+            WSLVersionCapability::DistributionInitPid,
         )?;
         Ok(self.0.InitPid)
     }
@@ -112,20 +112,26 @@ impl CoreWSLDistributionInformation for WSLDistributionInformation {
         opt_wide_str(self.0.PackageFamilyName)
     }
 
+    /// Retrieves the distribution flavor.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
     #[inline]
     fn flavor(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionFlavor,
         )?;
         Ok(opt_wide_str(self.0.Flavor))
     }
 
+    /// Retrieves the distribution version.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     #[inline]
     fn version(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionVersion,
         )?;
         Ok(opt_wide_str(self.0.Version))
     }

--- a/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
@@ -4,12 +4,10 @@
 //! offering a safe and idiomatic Rust interface for accessing offline distribution details.
 
 use crate::{
-    api::{
-        errors::require_update_error::Result, utils::check_required_version_result_from_context,
-    },
+    api::{errors::require_update_error::Result, utils::check_capability_result_from_context},
     core_wsl_distribution_information::CoreWSLDistributionInformation,
     utils::opt_wide_str,
-    UserDistributionID, WSLContext, WSLVersion,
+    UserDistributionID, WSLContext, WSLVersionCapability,
 };
 use std::{
     ffi::OsString,
@@ -87,20 +85,26 @@ impl CoreWSLDistributionInformation for WSLOfflineDistributionInformation {
         opt_wide_str(self.0.PackageFamilyName)
     }
 
+    /// Retrieves the distribution flavor.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
     #[inline]
     fn flavor(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionFlavor,
         )?;
         Ok(opt_wide_str(self.0.Flavor))
     }
 
+    /// Retrieves the distribution version.
+    ///
+    /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     #[inline]
     fn version(&self) -> Result<Option<OsString>> {
-        check_required_version_result_from_context(
+        check_capability_result_from_context(
             WSLContext::get_current(),
-            &WSLVersion::new(2, 4, 4),
+            WSLVersionCapability::DistributionVersion,
         )?;
         Ok(opt_wide_str(self.0.Version))
     }

--- a/crates/wslplugins-rs/src/wsl_version.rs
+++ b/crates/wslplugins-rs/src/wsl_version.rs
@@ -4,9 +4,13 @@ use std::{
     ptr,
     str::FromStr,
 };
+use strum::IntoEnumIterator;
 
 mod parse_error;
 pub use parse_error::WSLVersionParseError;
+
+mod capability;
+pub use capability::WSLVersionCapability;
 
 #[cfg(feature = "semver")]
 mod semver_impl;
@@ -87,6 +91,30 @@ impl WSLVersion {
     #[inline]
     pub const fn set_revision(&mut self, revision: u32) {
         self.0.Revision = revision;
+    }
+
+    /// Returns `true` when this version is greater than or equal to `required_version`.
+    #[must_use]
+    #[inline]
+    pub const fn is_at_least(&self, required_version: Self) -> bool {
+        self.major() > required_version.major()
+            || (self.major() == required_version.major()
+                && (self.minor() > required_version.minor()
+                    || (self.minor() == required_version.minor()
+                        && self.revision() >= required_version.revision())))
+    }
+
+    /// Returns `true` when this version supports the requested capability.
+    #[must_use]
+    #[inline]
+    pub const fn supports(&self, capability: WSLVersionCapability) -> bool {
+        self.is_at_least(capability.required_version())
+    }
+
+    /// Iterates over every capability supported by this version, ordered by required version.
+    #[inline]
+    pub fn capabilities(&self) -> impl Iterator<Item = WSLVersionCapability> + '_ {
+        WSLVersionCapability::iter().filter(|capability| self.supports(*capability))
     }
 }
 
@@ -181,6 +209,12 @@ impl FromStr for WSLVersion {
 mod tests {
     use super::*;
     use crate::utils::test_transparence;
+    use proptest::prelude::*;
+
+    fn arb_wsl_version() -> impl Strategy<Value = WSLVersion> {
+        (any::<u32>(), any::<u32>(), any::<u32>())
+            .prop_map(|(major, minor, revision)| WSLVersion::new(major, minor, revision))
+    }
 
     #[test]
     fn test_layouts() {
@@ -233,5 +267,87 @@ mod tests {
                 input: "2.0.a".to_owned(),
             })
         );
+    }
+
+    #[test]
+    fn supports_capability_when_version_is_high_enough() {
+        let version = WSLVersion::new(2, 1, 2);
+
+        assert!(version.supports(WSLVersionCapability::DistributionRegisteredHook));
+    }
+
+    #[test]
+    fn rejects_capability_when_version_is_too_low() {
+        let version = WSLVersion::new(2, 1, 1);
+
+        assert!(!version.supports(WSLVersionCapability::DistributionRegisteredHook));
+    }
+
+    #[test]
+    fn capabilities_iterates_supported_capabilities_by_required_version() {
+        let version = WSLVersion::new(2, 4, 4);
+        let capabilities = version.capabilities().collect::<Vec<_>>();
+
+        assert_eq!(
+            capabilities,
+            vec![
+                WSLVersionCapability::DistributionInitPid,
+                WSLVersionCapability::DistributionRegisteredHook,
+                WSLVersionCapability::DistributionUnregisteredHook,
+                WSLVersionCapability::ExecuteBinaryInDistribution,
+                WSLVersionCapability::DistributionFlavor,
+                WSLVersionCapability::DistributionVersion,
+            ]
+        );
+    }
+
+    #[test]
+    fn capabilities_excludes_capabilities_that_require_newer_versions() {
+        let version = WSLVersion::new(2, 1, 2);
+        let capabilities = version.capabilities().collect::<Vec<_>>();
+
+        assert_eq!(
+            capabilities,
+            vec![
+                WSLVersionCapability::DistributionInitPid,
+                WSLVersionCapability::DistributionRegisteredHook,
+                WSLVersionCapability::DistributionUnregisteredHook,
+                WSLVersionCapability::ExecuteBinaryInDistribution,
+            ]
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn from_str_roundtrips_displayed_versions(version in arb_wsl_version()) {
+            prop_assert_eq!(version.to_string().parse::<WSLVersion>(), Ok(version));
+        }
+
+        #[test]
+        fn is_at_least_matches_derived_ordering(
+            current in arb_wsl_version(),
+            required in arb_wsl_version(),
+        ) {
+            prop_assert_eq!(current.is_at_least(required), current >= required);
+        }
+
+        #[test]
+        fn supports_matches_capability_required_version(version in arb_wsl_version()) {
+            for capability in WSLVersionCapability::iter() {
+                prop_assert_eq!(
+                    version.supports(capability),
+                    version.is_at_least(capability.required_version())
+                );
+            }
+        }
+
+        #[test]
+        fn capabilities_iterates_exactly_supported_capabilities(version in arb_wsl_version()) {
+            let expected = WSLVersionCapability::iter()
+                .filter(|capability| version.supports(*capability))
+                .collect::<Vec<_>>();
+
+            prop_assert_eq!(version.capabilities().collect::<Vec<_>>(), expected);
+        }
     }
 }

--- a/crates/wslplugins-rs/src/wsl_version/capability.rs
+++ b/crates/wslplugins-rs/src/wsl_version/capability.rs
@@ -1,0 +1,92 @@
+use super::WSLVersion;
+use crate::api::errors::RequirementDefinition;
+use std::collections::HashSet;
+use strum::{Display, EnumIter};
+
+/// WSL Plugin API capabilities that are only available from a specific API version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumIter)]
+#[non_exhaustive]
+pub enum WSLVersionCapability {
+    /// Access to `WSLDistributionInformation::InitPid` (`2.0.5`).
+    DistributionInitPid,
+    /// Notification sent when a distribution is registered (`2.1.2`).
+    DistributionRegisteredHook,
+    /// Notification sent when a distribution is unregistered (`2.1.2`).
+    DistributionUnregisteredHook,
+    /// Execute a command inside a specific user distribution (`2.1.2`).
+    ExecuteBinaryInDistribution,
+    /// Access to the distribution flavor field (`2.4.4`).
+    DistributionFlavor,
+    /// Access to the distribution version field (`2.4.4`).
+    DistributionVersion,
+}
+
+impl WSLVersionCapability {
+    /// Returns the minimum WSL Plugin API version required for this capability.
+    #[must_use]
+    #[inline]
+    pub const fn required_version(self) -> WSLVersion {
+        match self {
+            Self::DistributionInitPid => WSLVersion::new(2, 0, 5),
+            Self::DistributionRegisteredHook
+            | Self::DistributionUnregisteredHook
+            | Self::ExecuteBinaryInDistribution => WSLVersion::new(2, 1, 2),
+            Self::DistributionFlavor | Self::DistributionVersion => WSLVersion::new(2, 4, 4),
+        }
+    }
+}
+
+impl TryFrom<RequirementDefinition> for WSLVersionCapability {
+    type Error = RequirementDefinition;
+
+    #[inline]
+    fn try_from(value: RequirementDefinition) -> std::result::Result<Self, Self::Error> {
+        match value {
+            RequirementDefinition::Capabilities(capabilities) if capabilities.len() == 1 => {
+                capabilities
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| RequirementDefinition::Capabilities(HashSet::new()))
+            }
+            requirement => Err(requirement),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use strum::IntoEnumIterator as _;
+
+    fn arb_capability() -> impl Strategy<Value = WSLVersionCapability> {
+        prop::sample::select(WSLVersionCapability::iter().collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn single_capability_requirement_can_be_recovered() {
+        let capability = WSLVersionCapability::ExecuteBinaryInDistribution;
+        let requirement = RequirementDefinition::from(capability);
+
+        assert_eq!(WSLVersionCapability::try_from(requirement), Ok(capability));
+    }
+
+    #[test]
+    fn multi_capability_requirement_cannot_be_recovered_as_single_capability() {
+        let requirement = RequirementDefinition::from([
+            WSLVersionCapability::DistributionRegisteredHook,
+            WSLVersionCapability::DistributionUnregisteredHook,
+        ]);
+
+        assert!(WSLVersionCapability::try_from(requirement).is_err());
+    }
+
+    proptest! {
+        #[test]
+        fn single_capability_requirement_roundtrips(capability in arb_capability()) {
+            let requirement = RequirementDefinition::from(capability);
+
+            prop_assert_eq!(WSLVersionCapability::try_from(requirement), Ok(capability));
+        }
+    }
+}

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -13,11 +13,11 @@ Most plugin crates should depend on `wslplugins-rs` with the `macro` feature ena
 wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
 ```
 
-The `macro` feature provides the `#[wsl_plugin_v1(...)]` attribute used to generate the WSL plugin entry points.
+The `macro` feature provides the `#[wsl_plugin_v1]` attribute used to generate the WSL plugin entry points.
 
 ## Minimal Shape
 
-Implement `WSLPluginV1` for your plugin type, then annotate the implementation with the WSL API version your plugin targets.
+Implement `WSLPluginV1` for your plugin type, then annotate the implementation.
 
 ```rust
 use wslplugins_rs::prelude::*;
@@ -26,7 +26,7 @@ pub(crate) struct MyPlugin {
 	context: &'static WSLContext,
 }
 
-#[wsl_plugin_v1(2, 0, 5)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for MyPlugin {
 	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
 		Ok(Self { context })
@@ -34,7 +34,81 @@ impl WSLPluginV1 for MyPlugin {
 }
 ```
 
-The macro generates the exported functions expected by WSL.
+The macro generates the exported functions expected by WSL, initializes the shared `WSLContext`, creates one plugin instance by calling `try_new`, and wires implemented hook methods into the WSL hook table.
+
+## API Requirements
+
+The macro can also check that the host WSL Plugin API supports the version or capability required
+before the plugin is initialized.
+
+Use no argument when the plugin only needs the base entry point:
+
+```rust
+#[wsl_plugin_v1]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+Use an explicit version when the whole plugin depends on a specific minimum API version:
+
+```rust
+#[wsl_plugin_v1(2, 1)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+```rust
+#[wsl_plugin_v1(2, 1, 2)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+Use named capabilities when the plugin depends on specific API features:
+
+```rust
+#[wsl_plugin_v1(WSLVersionCapability::DistributionRegisteredHook)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+Multiple capabilities can be combined with `|`. The macro requires the highest WSL version needed by the listed capabilities:
+
+```rust
+#[wsl_plugin_v1(
+	WSLVersionCapability::DistributionRegisteredHook
+	| WSLVersionCapability::DistributionUnregisteredHook
+)]
+impl WSLPluginV1 for MyPlugin {
+	fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+		Ok(Self { context })
+	}
+}
+```
+
+If the version check fails, WSL receives `WSL_E_PLUGIN_REQUIRES_UPDATE` and the plugin is not initialized.
+
+The complete capability list is maintained in the book's
+[Version Capabilities](../book/src/version-capabilities.md) chapter.
+
+## Version-Gated Hooks
+
+Some hook fields are available only on newer WSL Plugin API versions. For example, distribution registration and unregistration hooks require the matching `WSLVersionCapability`.
+
+When a plugin implements one of these hooks, the generated entry point checks the host API version before writing that hook into the hook table. On older hosts, the plugin can still initialize, but the unsupported hook is skipped.
+
+If the plugin cannot operate correctly without those hooks, list the capability in `#[wsl_plugin_v1(...)]` so initialization fails on unsupported hosts.
 
 ## Reliability
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -10,7 +10,7 @@ Most plugin crates should depend on `wslplugins-rs` with the `macro` feature ena
 
 ```toml
 [dependencies]
-wslplugins-rs = { version = "0.1.0-beta.3", features = ["macro"] }
+wslplugins-rs = { version = "0.1.0-beta.4", features = ["macro"] }
 ```
 
 The `macro` feature provides the `#[wsl_plugin_v1]` attribute used to generate the WSL plugin entry points.

--- a/examples/dist-info/Cargo.toml
+++ b/examples/dist-info/Cargo.toml
@@ -16,7 +16,7 @@ wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "macro",
   "bitflags",
   "tracing",
-], version = "0.1.0-beta.3" }
+], version = "0.1.0-beta.4" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"

--- a/examples/dist-info/src/lib.rs
+++ b/examples/dist-info/src/lib.rs
@@ -55,7 +55,7 @@ fn setup_logging() -> WinResult<()> {
     Ok(())
 }
 
-#[wsl_plugin_v1(2, 1, 2)]
+#[wsl_plugin_v1(WSLVersionCapability::ExecuteBinaryInDistribution)]
 impl WSLPluginV1 for Plugin {
     fn try_new(context: &'static WSLContext) -> WinResult<Self> {
         setup_logging()?;

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "macro",
-], version = "0.1.0-beta.3" }
+], version = "0.1.0-beta.4" }
 [dependencies.windows]
 workspace = true
 features = ["Win32_Foundation"]

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -6,9 +6,13 @@ It keeps the same observable behavior as the original sample:
 - it opens `C:\wsl-plugin-demo.txt` when the plugin is loaded
 - it logs VM and distribution lifecycle events
 - it runs `/bin/cat /proc/version` when the VM starts
-- it requires WSL `2.1.3` because it uses distribution registration hooks
+- it handles the same registration lifecycle events as the sample plugin
 
 The remaining differences stem from the framework architecture and idiomatic Rust:
-- `#[wsl_plugin_v1(2, 1, 3)]` generates the entry point and hook registration using the [`wslplugins_rs::wsl_plugin_v1`] macro
+- `#[wsl_plugin_v1(...)]` generates the entry point and hook registration using the [`wslplugins_rs::wsl_plugin_v1`] macro
 - [`wslplugins_rs::plugin::WSLPluginV1`] stores plugin state in a Rust struct instead of global variables
 - `ApiV1::new_command(...).execute()` replaces the manual `ExecuteBinary` and socket handling using the [`wslplugins_rs::api::WSLCommand`] API
+
+New plugins should prefer named `WSLVersionCapability` requirements where available. The book's
+version capabilities chapter lists the capabilities for registration hooks, distribution-scoped
+command execution, and version-gated distribution fields.

--- a/examples/unpackaged-distro-blacklist-policy/Cargo.toml
+++ b/examples/unpackaged-distro-blacklist-policy/Cargo.toml
@@ -16,7 +16,7 @@ wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "macro",
   "bitflags",
   "tracing",
-], version = "0.1.0-beta.3" }
+], version = "0.1.0-beta.4" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -51,7 +51,7 @@ fn setup_logging() -> WinResult<()> {
 #[derive(Debug)]
 pub(crate) struct Plugin;
 
-#[wsl_plugin_v1(2, 1, 2)]
+#[wsl_plugin_v1]
 impl WSLPluginV1 for Plugin {
     fn try_new(_context: &'static WSLContext) -> WinResult<Self> {
         setup_logging()?;


### PR DESCRIPTION
## Summary

Release branch for `0.1.0-beta.4`.

Compared with `main`, this release includes:
- workspace and crate version bumps to `0.1.0-beta.4`
- a new mdBook documentation set under `book/`
- new release/docs files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and `docs/`
- a new GitHub workflow for book publishing: `.github/workflows/book.yml`
- API and type work around WSL version capabilities, version parsing, serde support, and distribution/user ID changes
- command/execution and plugin updates needed for the newer APIs
- example updates to align with the new versions and APIs

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features`

## Notes

- This PR is not just a version bump: it includes the full set of feature and documentation changes that accumulated on `develop` since `main`.
- The release commit itself is `Release 0.1.0-beta.4`.
- `main` should only be merged from this release branch through GitHub.