### PR TITLE
Use safe borrowed session security identifier and token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 [workspace.dependencies]
 wslpluginapi-sys = "0.2.0"
-win-security-identifier = { version = "0.1.0", git = "https://github.com/mveril/win-security-identifier.git", branch = "release/0.1.0" }
+win-security-identifier = "0.1.0"
 windows-core = ">=0.57.0"
 windows = ">=0.57.0"
 quote = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 ]
 [workspace.dependencies]
 wslpluginapi-sys = "0.2.0"
+win-security-identifier = "0.1.0"
 windows-core = ">=0.57.0"
 windows = ">=0.57.0"
 quote = "1"
@@ -22,7 +23,6 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mveril/wslplugins-rs"
 description = "A Rust framework for developing WSL plugins using safe and idiomatic Rust."
-
 
 [workspace.lints.rust]
 unused = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 [workspace.dependencies]
 wslpluginapi-sys = "0.2.0"
-win-security-identifier = "0.1.0"
+win-security-identifier = "0.1.1"
 windows-core = ">=0.57.0"
 windows = ">=0.57.0"
 quote = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 ]
 [workspace.dependencies]
 wslpluginapi-sys = "0.2.0"
+win-security-identifier = { version = "0.1.0", git = "https://github.com/mveril/win-security-identifier.git", branch = "release/0.1.0" }
 windows-core = ">=0.57.0"
 windows = ">=0.57.0"
 quote = "1"
@@ -22,7 +23,6 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mveril/wslplugins-rs"
 description = "A Rust framework for developing WSL plugins using safe and idiomatic Rust."
-
 
 [workspace.lints.rust]
 unused = "warn"

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -66,7 +66,9 @@ it must outlive the hook.
 The public crate provides typed wrappers for common WSL concepts:
 
 - `WSLContext`: plugin context and access to `ApiV1`.
-- `WSLSessionInformation`: current WSL session metadata.
+- `WSLSessionInformation`: current WSL session metadata, including borrowed access to
+  the user token and security identifier through `user_token()` and `user_sid()`.
+  These values remain owned by the WSL session and must not be closed or freed.
 - `WSLDistributionInformation`: online distribution metadata.
 - `WSLOfflineDistributionInformation`: offline distribution metadata used by registration hooks.
 - `WSLVmCreationSettings`: VM creation settings.

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -56,6 +56,3 @@ workspace = true
 [[bench]]
 name = "user_distribution_id_formatting"
 harness = false
-default = ["smallvec"]
-sys = []
-smallvec = ["dep:smallvec"]

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -22,6 +22,7 @@ typed-path = ">0.1"
 widestring = { version = "1", features = ["alloc"] }
 wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.4" }
 wslpluginapi-sys.workspace = true
+win-security-identifier.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }
 semver = { version = "1", optional = true }
@@ -36,8 +37,9 @@ serde_test = "1"
 default = ["smallvec"]
 sys = []
 smallvec = ["dep:smallvec"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "win-security-identifier/serde"]
 macro = ["dep:wslplugins-macro", "sys", "dep:tracing"]
+sid-macro = ["win-security-identifier/macro"]
 tracing = ["dep:tracing"]
 uuid = ["dep:uuid"]
 semver = ["dep:semver"]
@@ -54,3 +56,6 @@ workspace = true
 [[bench]]
 name = "user_distribution_id_formatting"
 harness = false
+default = ["smallvec"]
+sys = []
+smallvec = ["dep:smallvec"]

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -37,8 +37,9 @@ serde_test = "1"
 default = ["smallvec"]
 sys = []
 smallvec = ["dep:smallvec"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "win-security-identifier/serde"]
 macro = ["dep:wslplugins-macro", "sys", "dep:tracing"]
+sid-macro = ["win-security-identifier/macro"]
 tracing = ["dep:tracing"]
 uuid = ["dep:uuid"]
 semver = ["dep:semver"]
@@ -55,3 +56,6 @@ workspace = true
 [[bench]]
 name = "user_distribution_id_formatting"
 harness = false
+default = ["smallvec"]
+sys = []
+smallvec = ["dep:smallvec"]

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -22,6 +22,7 @@ typed-path = ">0.1"
 widestring = { version = "1", features = ["alloc"] }
 wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.4" }
 wslpluginapi-sys.workspace = true
+win-security-identifier.workspace = true
 uuid = { version = "1", optional = true }
 smallvec = { workspace = true, optional = true }
 semver = { version = "1", optional = true }

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -62,6 +62,8 @@ mod wsl_vm_creation_settings;
 #[cfg(doc)]
 use crate::plugin::WSLPluginV1;
 pub mod wsl_user_configuration;
+/// Re-exports the `win-security-identifier` crate for working with Windows SIDs.
+pub use win_security_identifier;
 pub use typed_path;
 pub use wsl_user_configuration::WSLUserConfiguration;
 /// Tools and utilities for creating custom WSL plugins.

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -62,9 +62,9 @@ mod wsl_vm_creation_settings;
 #[cfg(doc)]
 use crate::plugin::WSLPluginV1;
 pub mod wsl_user_configuration;
+pub use typed_path;
 /// Re-exports the `win-security-identifier` crate for working with Windows SIDs.
 pub use win_security_identifier;
-pub use typed_path;
 pub use wsl_user_configuration::WSLUserConfiguration;
 /// Tools and utilities for creating custom WSL plugins.
 pub mod plugin;

--- a/crates/wslplugins-rs/src/wsl_session_information.rs
+++ b/crates/wslplugins-rs/src/wsl_session_information.rs
@@ -26,17 +26,13 @@ impl WSLSessionInformation {
         SessionID(self.0.SessionId)
     }
 
-    /// Retrieves the user token for the session.
+    /// Retrieves the user token for the session as a [BorrowedHandle].
     ///
-    /// # Returns
-    /// A [BorrowedHandle] representing the user token.
-    /// # Safety
-    /// This function returns a [BorrowedHandle] to the user token.
-    /// The handle should be used only during the life of the session and must not be closed
     #[must_use]
     #[inline]
-    pub const unsafe fn user_token(&self) -> BorrowedHandle<'_> {
-        BorrowedHandle::borrow_raw(self.0.UserToken)
+    pub const fn user_token(&self) -> BorrowedHandle<'_> {
+        // SAFETY: The user token is a valid handle for the duration of the session, and we are only borrowing it.
+        unsafe { BorrowedHandle::borrow_raw(self.0.UserToken) }
     }
 
     /// Retrieves the user SID (security identifier) for the session.

--- a/crates/wslplugins-rs/src/wsl_session_information.rs
+++ b/crates/wslplugins-rs/src/wsl_session_information.rs
@@ -5,7 +5,7 @@
 
 use crate::{HasSessionId, SessionID};
 use core::hash;
-use std::{fmt, os::windows::raw::HANDLE};
+use std::{fmt, os::windows::io::BorrowedHandle};
 use win_security_identifier::Sid;
 
 /// Represents session information for a WSL instance.
@@ -26,17 +26,12 @@ impl WSLSessionInformation {
         SessionID(self.0.SessionId)
     }
 
-    /// Retrieves the user token for the session.
-    ///
-    /// # Returns
-    /// A [HANDLE] representing the user token.
-    /// # Safety
-    /// This function returns a raw handle to the user token.
-    /// The handle should be used only during the life of the session and must not be closed
+    /// Retrieves the user token for the session as a [`BorrowedHandle`].
     #[must_use]
     #[inline]
-    pub const unsafe fn user_token(&self) -> HANDLE {
-        self.0.UserToken
+    pub const fn user_token(&self) -> BorrowedHandle<'_> {
+        // SAFETY: The user token is a valid handle for the duration of the session, and we are only borrowing it.
+        unsafe { BorrowedHandle::borrow_raw(self.0.UserToken) }
     }
 
     /// Retrieves the user SID (security identifier) for the session.

--- a/crates/wslplugins-rs/src/wsl_session_information.rs
+++ b/crates/wslplugins-rs/src/wsl_session_information.rs
@@ -5,7 +5,7 @@
 
 use crate::{HasSessionId, SessionID};
 use core::hash;
-use std::{fmt, os::windows::raw::HANDLE};
+use std::{fmt, os::windows::io::BorrowedHandle};
 use wslpluginapi_sys::windows_sys::Win32::Security::PSID;
 
 /// Represents session information for a WSL instance.
@@ -29,14 +29,14 @@ impl WSLSessionInformation {
     /// Retrieves the user token for the session.
     ///
     /// # Returns
-    /// A [HANDLE] representing the user token.
+    /// A [BorrowedHandle] representing the user token.
     /// # Safety
-    /// This function returns a raw handle to the user token.
+    /// This function returns a [BorrowedHandle] to the user token.
     /// The handle should be used only during the life of the session and must not be closed
     #[must_use]
     #[inline]
-    pub const unsafe fn user_token(&self) -> HANDLE {
-        self.0.UserToken
+    pub const unsafe fn user_token(&self) -> BorrowedHandle<'_> {
+        BorrowedHandle::borrow_raw(self.0.UserToken)
     }
 
     /// Retrieves the user SID (security identifier) for the session.

--- a/crates/wslplugins-rs/src/wsl_session_information.rs
+++ b/crates/wslplugins-rs/src/wsl_session_information.rs
@@ -40,16 +40,11 @@ impl WSLSessionInformation {
     }
 
     /// Retrieves the user SID (security identifier) for the session.
-    ///
-    /// # Returns
-    /// A [PSID] representing the user SID.
-    /// # Safety
-    /// This function returns a raw pointer to the user SID.
-    /// This pointer should be used only during the life of the session and must not be freed or modified.
     #[must_use]
     #[inline]
-    pub const unsafe fn user_sid(&self) -> &Sid {
-        Sid::from_raw(self.0.UserSid)
+    pub const fn user_sid(&self) -> &Sid {
+        // SAFETY: The WSL Plugin API guarantees that the `UserSid` field is a valid pointer to a SID structure.
+        unsafe { Sid::from_raw(self.0.UserSid) }
     }
 }
 
@@ -124,7 +119,7 @@ impl fmt::Debug for WSLSessionInformation {
         f.debug_struct("WSLSessionInformation")
             .field("sessionId", &self.0.SessionId)
             .field("userToken", &self.0.UserToken)
-            .field("userSid", &self.0.UserSid)
+            .field("userSid", &self.user_sid())
             .finish()
     }
 }

--- a/crates/wslplugins-rs/src/wsl_session_information.rs
+++ b/crates/wslplugins-rs/src/wsl_session_information.rs
@@ -6,7 +6,7 @@
 use crate::{HasSessionId, SessionID};
 use core::hash;
 use std::{fmt, os::windows::raw::HANDLE};
-use wslpluginapi_sys::windows_sys::Win32::Security::PSID;
+use win_security_identifier::Sid;
 
 /// Represents session information for a WSL instance.
 ///
@@ -48,8 +48,8 @@ impl WSLSessionInformation {
     /// This pointer should be used only during the life of the session and must not be freed or modified.
     #[must_use]
     #[inline]
-    pub const unsafe fn user_sid(&self) -> PSID {
-        self.0.UserSid
+    pub const unsafe fn user_sid(&self) -> &Sid {
+        Sid::from_raw(self.0.UserSid)
     }
 }
 

--- a/crates/wslplugins-rs/src/wsl_session_information.rs
+++ b/crates/wslplugins-rs/src/wsl_session_information.rs
@@ -6,7 +6,7 @@
 use crate::{HasSessionId, SessionID};
 use core::hash;
 use std::{fmt, os::windows::raw::HANDLE};
-use wslpluginapi_sys::windows_sys::Win32::Security::PSID;
+use win_security_identifier::Sid;
 
 /// Represents session information for a WSL instance.
 ///
@@ -40,16 +40,11 @@ impl WSLSessionInformation {
     }
 
     /// Retrieves the user SID (security identifier) for the session.
-    ///
-    /// # Returns
-    /// A [PSID] representing the user SID.
-    /// # Safety
-    /// This function returns a raw pointer to the user SID.
-    /// This pointer should be used only during the life of the session and must not be freed or modified.
     #[must_use]
     #[inline]
-    pub const unsafe fn user_sid(&self) -> PSID {
-        self.0.UserSid
+    pub const fn user_sid(&self) -> &Sid {
+        // SAFETY: The WSL Plugin API guarantees that the `UserSid` field is a valid pointer to a SID structure.
+        unsafe { Sid::from_raw(self.0.UserSid) }
     }
 }
 
@@ -124,7 +119,7 @@ impl fmt::Debug for WSLSessionInformation {
         f.debug_struct("WSLSessionInformation")
             .field("sessionId", &self.0.SessionId)
             .field("userToken", &self.0.UserToken)
-            .field("userSid", &self.0.UserSid)
+            .field("userSid", &self.user_sid())
             .finish()
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -12,4 +12,7 @@ wildcards = "deny"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = ["https://github.com/mveril/wslpluginapi-sys"]
+allow-git = [
+  "https://github.com/mveril/wslpluginapi-sys",
+  "https://github.com/mveril/win-security-identifier",
+]


### PR DESCRIPTION
## Summary

- expose the session user token as a borrowed Windows handle
- expose the session user SID through win-security-identifier
- document the borrowed ownership model and related crate features

## Impact

The public session APIs no longer require callers to handle raw HANDLE and PSID values directly. Their lifetimes are tied to WSLSessionInformation, preventing callers from closing or freeing WSL-owned resources.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace --all-features