### PR TITLE
Borrow distribution strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ quote = "1"
 syn = "2"
 proc-macro2 = "1"
 smallvec = "1" 
+widestring = "1"
 strum = { version = "0.28", features = ["derive"] }
 
 [workspace.package]

--- a/book/src/version-capabilities.md
+++ b/book/src/version-capabilities.md
@@ -121,7 +121,7 @@ fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> 
         .flavor()
         .ok()
         .flatten()
-        .map(|value| value.to_string_lossy().into_owned())
+        .map(|value| value.to_string_lossy().to_owned())
 }
 ```
 

--- a/book/src/version-capabilities.md
+++ b/book/src/version-capabilities.md
@@ -121,7 +121,7 @@ fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> 
         .flavor()
         .ok()
         .flatten()
-        .map(|value| value.to_string_lossy().to_owned())
+        .map(|value| value.to_string_lossy())
 }
 ```
 

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -133,7 +133,7 @@ fn describe_distribution(distribution: &WSLDistributionInformation) -> PluginRes
     let init_pid = distribution.init_pid()?;
     Ok(format!(
         "{} is running with init PID {init_pid}",
-        distribution.name().to_string_lossy()
+        distribution.name().display()
     ))
 }
 ```

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -138,6 +138,11 @@ fn describe_distribution(distribution: &WSLDistributionInformation) -> PluginRes
 }
 ```
 
+Distribution string accessors such as `name()` and `package_family_name()` return borrowed
+`U16CStr` values. They expose the UTF-16 strings supplied by the WSL Plugin API without allocating
+or copying. The returned references are valid for the lifetime of the borrowed distribution
+information. Use `to_os_string()` only when an owned native string is required.
+
 If the runtime API is too old for `init_pid()`, the call returns a `RequiresUpdate` error that maps
 to `WSL_E_PLUGIN_REQUIRES_UPDATE`. The same pattern is used by distribution-scoped command
 execution: `with_distribution_id(DistributionID::User(...)).execute()` requires

--- a/book/src/wsl-plugin-model.md
+++ b/book/src/wsl-plugin-model.md
@@ -160,7 +160,7 @@ fn optional_flavor(distribution: &WSLDistributionInformation) -> Option<String> 
         .flavor()
         .ok()
         .flatten()
-        .map(|value| value.to_string_lossy().into_owned())
+        .map(|value| value.to_string_lossy())
 }
 ```
 

--- a/crates/wslplugins-macro-core/src/lib.rs
+++ b/crates/wslplugins-macro-core/src/lib.rs
@@ -109,8 +109,8 @@ mod test {
                         "Distribution started. Sessionid= {:}, Id={:?} Name={:}, Package={}, PidNs={}, InitPid={}",
                         session.id(),
                         distribution.id(),
-                        distribution.name().to_string_lossy(),
-                        distribution.package_family_name().unwrap_or_default().to_string_lossy(),
+                        distribution.name().display(),
+                        distribution.package_family_name().unwrap_or_default().display(),
                         distribution.pid_namespace(),
                         distribution.init_pid().unwrap()
                     );
@@ -132,8 +132,8 @@ mod test {
                         "Distribution Stopping. SessionId={}, Id={:?} name={}, package={}, PidNs={}, InitPid={}",
                         session.id(),
                         distribution.id(),
-                        distribution.name().to_string_lossy(),
-                        distribution.package_family_name().unwrap_or_default().to_string_lossy(),
+                        distribution.name().display(),
+                        distribution.package_family_name().unwrap_or_default().display(),
                         distribution.pid_namespace(),
                         distribution.init_pid().unwrap()
                     );

--- a/crates/wslplugins-macro-tests/tests/ui/success.rs
+++ b/crates/wslplugins-macro-tests/tests/ui/success.rs
@@ -1,5 +1,5 @@
 use windows::core::Result as WinResult;
-use wslplugins_rs::plugin::{WSLPluginV1, Result};
+use wslplugins_rs::plugin::{Result, WSLPluginV1};
 use wslplugins_rs::*;
 
 pub(crate) struct Plugin {
@@ -33,8 +33,8 @@ impl WSLPluginV1 for Plugin {
             "Distribution started. Sessionid= {:}, Id={:?} Name={:}, Package={}, PidNs={}, InitPid={}",
             session.id(),
             distribution.id(),
-            distribution.name().to_string_lossy(),
-            distribution.package_family_name().unwrap_or_default().to_string_lossy(),
+            distribution.name().display(),
+            distribution.package_family_name().unwrap_or_default().display(),
             distribution.pid_namespace(),
             distribution.init_pid().unwrap()
         );
@@ -55,8 +55,8 @@ impl WSLPluginV1 for Plugin {
             "Distribution Stopping. SessionId={}, Id={:?} name={}, package={}, PidNs={}, InitPid={}",
             session.id(),
             distribution.id(),
-            distribution.name().to_string_lossy(),
-            distribution.package_family_name().unwrap_or_default().to_string_lossy(),
+            distribution.name().display(),
+            distribution.package_family_name().unwrap_or_default().display(),
             distribution.pid_namespace(),
             distribution.init_pid().unwrap()
         );

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 tracing = { version = "0.1.43", optional = true }
 thiserror = "2.0.7"
 typed-path = ">0.1"
-widestring = { version = "1", features = ["alloc"] }
+widestring.workspace = true
 wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.4" }
 wslpluginapi-sys.workspace = true
 win-security-identifier.workspace = true

--- a/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/core_wsl_distribution_information.rs
@@ -12,7 +12,7 @@
 #[cfg(doc)]
 use crate::WSLVersionCapability;
 use crate::{api::errors::require_update_error::Result, UserDistributionID};
-use std::ffi::OsString;
+use widestring::U16CStr;
 
 /// A trait representing the core information of a WSL distribution.
 ///
@@ -30,8 +30,8 @@ pub trait CoreWSLDistributionInformation {
     /// Retrieves the name of the distribution.
     ///
     /// # Returns
-    /// An [`OsString`] containing the display name of the distribution.
-    fn name(&self) -> OsString;
+    /// A borrowed UTF-16 string containing the display name of the distribution.
+    fn name(&self) -> &U16CStr;
 
     /// Retrieves the package family name of the distribution, if available.
     ///
@@ -40,7 +40,7 @@ pub trait CoreWSLDistributionInformation {
     /// # Returns
     /// - `Some(package_family_name)`: If the distribution has a package family name.
     /// - `None`: If the distribution is not packaged or the information is unavailable.
-    fn package_family_name(&self) -> Option<OsString>;
+    fn package_family_name(&self) -> Option<&U16CStr>;
 
     /// Retrieves the type of distribution (ubuntu, debian, ...), if available.
     ///
@@ -52,7 +52,7 @@ pub trait CoreWSLDistributionInformation {
     /// - `Err(e)`: if the API version is too low to retrieve this information.
     /// # Errors
     /// Returns an error if the API version is too low to retrieve this information.
-    fn flavor(&self) -> Result<Option<OsString>>;
+    fn flavor(&self) -> Result<Option<&U16CStr>>;
 
     /// Retrieves the version of the distribution, if available
     ///
@@ -64,5 +64,5 @@ pub trait CoreWSLDistributionInformation {
     /// - `Err(e)`: if the API version is too low to retrieve this information.
     /// # Errors
     /// Returns an error if the API version is too low to retrieve this information.
-    fn version(&self) -> Result<Option<OsString>>;
+    fn version(&self) -> Result<Option<&U16CStr>>;
 }

--- a/crates/wslplugins-rs/src/distribution_id.rs
+++ b/crates/wslplugins-rs/src/distribution_id.rs
@@ -126,7 +126,7 @@ mod tests {
     use super::*;
     use crate::api::errors::require_update_error::Result;
     use proptest::prelude::*;
-    use std::ffi::OsString;
+    use widestring::{u16cstr, U16CStr};
 
     #[derive(Clone, Copy)]
     struct TestDistribution {
@@ -138,19 +138,19 @@ mod tests {
             self.id
         }
 
-        fn name(&self) -> OsString {
-            OsString::from("test")
+        fn name(&self) -> &U16CStr {
+            u16cstr!("test")
         }
 
-        fn package_family_name(&self) -> Option<OsString> {
+        fn package_family_name(&self) -> Option<&U16CStr> {
             None
         }
 
-        fn flavor(&self) -> Result<Option<OsString>> {
+        fn flavor(&self) -> Result<Option<&U16CStr>> {
             Ok(None)
         }
 
-        fn version(&self) -> Result<Option<OsString>> {
+        fn version(&self) -> Result<Option<&U16CStr>> {
             Ok(None)
         }
     }

--- a/crates/wslplugins-rs/src/lib.rs
+++ b/crates/wslplugins-rs/src/lib.rs
@@ -65,6 +65,8 @@ mod wsl_vm_creation_settings;
 use crate::plugin::WSLPluginV1;
 pub mod wsl_user_configuration;
 pub use typed_path;
+/// Re-exports the `widestring` crate for borrowed UTF-16 strings exposed by this API.
+pub use widestring;
 /// Re-exports the `win-security-identifier` crate for working with Windows SIDs.
 pub use win_security_identifier;
 pub use wsl_user_configuration::WSLUserConfiguration;

--- a/crates/wslplugins-rs/src/utils.rs
+++ b/crates/wslplugins-rs/src/utils.rs
@@ -1,27 +1,40 @@
-use std::ffi::OsString;
 #[cfg(test)]
 use std::mem::{align_of, size_of};
-use std::os::windows::ffi::OsStringExt as _;
-use windows_core::PCWSTR;
+use widestring::U16CStr;
 #[cfg(test)]
 pub fn test_transparence<T, U>() {
     assert_eq!(align_of::<T>(), align_of::<U>());
     assert_eq!(size_of::<T>(), size_of::<U>());
 }
 
-pub fn opt_wide_str(ptr: *const u16) -> Option<OsString> {
+/// Borrows a null-terminated UTF-16 string from a raw pointer.
+///
+/// # Safety
+///
+/// `ptr` must point to a valid null-terminated UTF-16 string that remains alive for `'a`.
+pub unsafe fn wide_str<'a>(ptr: *const u16) -> &'a U16CStr {
+    // SAFETY: The caller guarantees that `ptr` points to a valid null-terminated UTF-16 string
+    // for the returned lifetime.
+    unsafe { U16CStr::from_ptr_str(ptr) }
+}
+
+/// Borrows a non-empty null-terminated UTF-16 string from a nullable raw pointer.
+///
+/// # Safety
+///
+/// A non-null `ptr` must point to a valid null-terminated UTF-16 string that remains alive for
+/// `'a`.
+pub unsafe fn opt_wide_str<'a>(ptr: *const u16) -> Option<&'a U16CStr> {
     if ptr.is_null() {
         None
     } else {
-        let wide_str = PCWSTR::from_raw(ptr);
-        // SAFETY: The caller guarantees that `ptr` is valid and points to a null-terminated wide string.
-        unsafe {
-            let wide = wide_str.as_wide();
-            if wide.is_empty() {
-                None
-            } else {
-                Some(OsString::from_wide(wide))
-            }
+        // SAFETY: The caller guarantees that `ptr` points to a valid null-terminated UTF-16
+        // string for the returned lifetime.
+        let wide = unsafe { wide_str(ptr) };
+        if wide.is_empty() {
+            None
+        } else {
+            Some(wide)
         }
     }
 }
@@ -33,13 +46,15 @@ mod tests {
     #[test]
     fn test_empty_as_wide_null() {
         let ptr = std::ptr::null();
-        assert_eq!(opt_wide_str(ptr), None);
+        // SAFETY: Null pointers are explicitly supported by `opt_wide_str`.
+        assert_eq!(unsafe { opt_wide_str(ptr) }, None);
     }
 
     #[test]
     fn test_empty_as_wide_empty() {
         let wide_str = [0u16; 1];
-        assert_eq!(opt_wide_str(wide_str.as_ptr()), None);
+        // SAFETY: `wide_str` is a valid null-terminated UTF-16 string for this scope.
+        assert_eq!(unsafe { opt_wide_str(wide_str.as_ptr()) }, None);
     }
 
     fn null_terminated_wide() -> impl Strategy<Value = Vec<u16>> {
@@ -59,11 +74,13 @@ mod tests {
 
             let ptr = wide.as_ptr();
 
-            let result = opt_wide_str(ptr);
+            // SAFETY: The strategy produces a null-terminated UTF-16 buffer that remains alive
+            // for the duration of the returned borrow.
+            let result = unsafe { opt_wide_str(ptr) };
             #[allow(clippy::indexing_slicing, reason="Safe because we know the last element is the null terminator")]
-            let expected = OsString::from_wide(&wide[..wide.len() - 1]);
+            let expected = &wide[..wide.len() - 1];
 
-            prop_assert_eq!(result, Some(expected));
+            prop_assert_eq!(result.map(U16CStr::as_slice), Some(expected));
         }
     }
 }

--- a/crates/wslplugins-rs/src/wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_distribution_information.rs
@@ -19,13 +19,12 @@ use crate::api::{
     errors::require_update_error::Result, utils::check_capability_result_from_context,
 };
 use crate::core_wsl_distribution_information::CoreWSLDistributionInformation;
-use crate::utils::opt_wide_str;
+use crate::utils::{opt_wide_str, wide_str};
 use crate::{UserDistributionID, WSLContext, WSLVersionCapability};
-use std::ffi::OsString;
 use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
-use std::os::windows::ffi::OsStringExt as _;
 use std::ptr;
+use widestring::U16CStr;
 use windows_core::PCWSTR;
 
 /// Represents detailed information about a WSL distribution.
@@ -102,38 +101,45 @@ impl CoreWSLDistributionInformation for WSLDistributionInformation {
     }
 
     #[inline]
-    fn name(&self) -> OsString {
-        // SAFETY: Name is known to be valid
-        unsafe { OsString::from_wide(PCWSTR::from_raw(self.0.Name).as_wide()) }
+    fn name(&self) -> &U16CStr {
+        // SAFETY: The WSL Plugin API guarantees that Name points to a valid null-terminated
+        // UTF-16 string for the lifetime of this distribution information.
+        unsafe { wide_str(self.0.Name) }
     }
 
     #[inline]
-    fn package_family_name(&self) -> Option<OsString> {
-        opt_wide_str(self.0.PackageFamilyName)
+    fn package_family_name(&self) -> Option<&U16CStr> {
+        // SAFETY: The WSL Plugin API guarantees that a non-null PackageFamilyName remains valid
+        // for the lifetime of this distribution information.
+        unsafe { opt_wide_str(self.0.PackageFamilyName) }
     }
 
     /// Retrieves the distribution flavor.
     ///
     /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
     #[inline]
-    fn flavor(&self) -> Result<Option<OsString>> {
+    fn flavor(&self) -> Result<Option<&U16CStr>> {
         check_capability_result_from_context(
             WSLContext::get_current(),
             WSLVersionCapability::DistributionFlavor,
         )?;
-        Ok(opt_wide_str(self.0.Flavor))
+        // SAFETY: The WSL Plugin API guarantees that a non-null Flavor remains valid for the
+        // lifetime of this distribution information.
+        Ok(unsafe { opt_wide_str(self.0.Flavor) })
     }
 
     /// Retrieves the distribution version.
     ///
     /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     #[inline]
-    fn version(&self) -> Result<Option<OsString>> {
+    fn version(&self) -> Result<Option<&U16CStr>> {
         check_capability_result_from_context(
             WSLContext::get_current(),
             WSLVersionCapability::DistributionVersion,
         )?;
-        Ok(opt_wide_str(self.0.Version))
+        // SAFETY: The WSL Plugin API guarantees that a non-null Version remains valid for the
+        // lifetime of this distribution information.
+        Ok(unsafe { opt_wide_str(self.0.Version) })
     }
 }
 

--- a/crates/wslplugins-rs/src/wsl_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_distribution_information.rs
@@ -25,7 +25,6 @@ use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::ptr;
 use widestring::U16CStr;
-use windows_core::PCWSTR;
 
 /// Represents detailed information about a WSL distribution.
 ///
@@ -166,14 +165,7 @@ impl Display for WSLDistributionInformation {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // SAFETY: Name is known to be valid
-        unsafe {
-            write!(
-                f,
-                "{} {{{}}}",
-                PCWSTR::from_raw(self.0.Name).display(),
-                self.id()
-            )
-        }
+        write!(f, "{} {{{}}}", self.name().display(), self.id())
     }
 }
 

--- a/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
@@ -15,7 +15,6 @@ use std::{
     ptr,
 };
 use widestring::U16CStr;
-use windows_core::PCWSTR;
 
 /// A wrapper around `WslOfflineDistributionInformation` providing a safe interface.
 ///
@@ -138,15 +137,7 @@ impl Hash for WSLOfflineDistributionInformation {
 impl Display for WSLOfflineDistributionInformation {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // SAFETY: Name is known to be valid
-        unsafe {
-            write!(
-                f,
-                "{} {{{}}}",
-                PCWSTR::from_raw(self.0.Name).display(),
-                self.id()
-            )
-        }
+        write!(f, "{} {{{}}}", self.name().display(), self.id())
     }
 }
 

--- a/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
+++ b/crates/wslplugins-rs/src/wsl_offline_distribution_information.rs
@@ -6,16 +6,15 @@
 use crate::{
     api::{errors::require_update_error::Result, utils::check_capability_result_from_context},
     core_wsl_distribution_information::CoreWSLDistributionInformation,
-    utils::opt_wide_str,
+    utils::{opt_wide_str, wide_str},
     UserDistributionID, WSLContext, WSLVersionCapability,
 };
 use std::{
-    ffi::OsString,
     fmt::{self, Debug, Display},
     hash::{Hash, Hasher},
-    os::windows::ffi::OsStringExt as _,
     ptr,
 };
+use widestring::U16CStr;
 use windows_core::PCWSTR;
 
 /// A wrapper around `WslOfflineDistributionInformation` providing a safe interface.
@@ -68,45 +67,52 @@ impl CoreWSLDistributionInformation for WSLOfflineDistributionInformation {
         self.0.Id.into()
     }
 
-    /// Retrieves the name of the offline distribution as an [`OsString`].
+    /// Retrieves the name of the offline distribution as a borrowed UTF-16 string.
     #[inline]
-    fn name(&self) -> OsString {
-        // SAFETY: name is known to be valid
-        unsafe { OsString::from_wide(PCWSTR::from_raw(self.0.Name).as_wide()) }
+    fn name(&self) -> &U16CStr {
+        // SAFETY: The WSL Plugin API guarantees that Name points to a valid null-terminated
+        // UTF-16 string for the lifetime of this distribution information.
+        unsafe { wide_str(self.0.Name) }
     }
 
     /// Retrieves the package family name of the offline distribution, if available.
     ///
     /// # Returns
-    /// - `Some(OsString)`: If the package family name is set.
+    /// - `Some(&U16CStr)`: If the package family name is set.
     /// - `None`: If the package family name is null or empty.
     #[inline]
-    fn package_family_name(&self) -> Option<OsString> {
-        opt_wide_str(self.0.PackageFamilyName)
+    fn package_family_name(&self) -> Option<&U16CStr> {
+        // SAFETY: The WSL Plugin API guarantees that a non-null PackageFamilyName remains valid
+        // for the lifetime of this distribution information.
+        unsafe { opt_wide_str(self.0.PackageFamilyName) }
     }
 
     /// Retrieves the distribution flavor.
     ///
     /// This requires [`WSLVersionCapability::DistributionFlavor`] (`2.4.4`).
     #[inline]
-    fn flavor(&self) -> Result<Option<OsString>> {
+    fn flavor(&self) -> Result<Option<&U16CStr>> {
         check_capability_result_from_context(
             WSLContext::get_current(),
             WSLVersionCapability::DistributionFlavor,
         )?;
-        Ok(opt_wide_str(self.0.Flavor))
+        // SAFETY: The WSL Plugin API guarantees that a non-null Flavor remains valid for the
+        // lifetime of this distribution information.
+        Ok(unsafe { opt_wide_str(self.0.Flavor) })
     }
 
     /// Retrieves the distribution version.
     ///
     /// This requires [`WSLVersionCapability::DistributionVersion`] (`2.4.4`).
     #[inline]
-    fn version(&self) -> Result<Option<OsString>> {
+    fn version(&self) -> Result<Option<&U16CStr>> {
         check_capability_result_from_context(
             WSLContext::get_current(),
             WSLVersionCapability::DistributionVersion,
         )?;
-        Ok(opt_wide_str(self.0.Version))
+        // SAFETY: The WSL Plugin API guarantees that a non-null Version remains valid for the
+        // lifetime of this distribution information.
+        Ok(unsafe { opt_wide_str(self.0.Version) })
     }
 }
 

--- a/examples/dist-info/src/lib.rs
+++ b/examples/dist-info/src/lib.rs
@@ -109,8 +109,8 @@ impl WSLPluginV1 for Plugin {
             "Distribution started. Sessionid= {:?}, Id={:?} Name={:}, Package={}, PidNs={}, InitPid={}",
             session.id(),
             distribution.id(),
-            distribution.name().to_string_lossy(),
-            distribution.package_family_name().unwrap_or_default().to_string_lossy(),
+            distribution.name().display(),
+            distribution.package_family_name().unwrap_or_default().display(),
             distribution.pid_namespace(),
             // Use unknow if init_pid not available
             distribution.init_pid().map(|res| res.to_string()).unwrap_or("Unknow".to_string())
@@ -135,8 +135,8 @@ impl WSLPluginV1 for Plugin {
             "Distribution Stopping. SessionId={:?}, Id={:?} name={}, package={}, PidNs={}, InitPid={}",
             session.id(),
             distribution.id(),
-            distribution.name().to_string_lossy(),
-            distribution.package_family_name().unwrap_or_default().to_string_lossy(),
+            distribution.name().display(),
+            distribution.package_family_name().unwrap_or_default().display(),
             distribution.pid_namespace(),
             // Use unknow if init_pid not available
             distribution.init_pid().map(|res| res.to_string()).unwrap_or("Unknow".to_string())

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -85,7 +85,7 @@ impl WSLPluginV1 for Plugin {
             &self.log_file,
             "Distribution started. Sessionid= {}, Name={}, Package={}, PidNs={}, InitPid={}",
             session.id(),
-            distribution.name().to_string_lossy(),
+            distribution.name().display(),
             distribution
                 .package_family_name()
                 .unwrap_or_default()
@@ -107,7 +107,7 @@ impl WSLPluginV1 for Plugin {
             &self.log_file,
             "Distribution Stopping. SessionId={}, name={}, package={}, PidNs={}, InitPid={}",
             session.id(),
-            distribution.name().to_string_lossy(),
+            distribution.name().display(),
             distribution
                 .package_family_name()
                 .unwrap_or_default()
@@ -128,7 +128,7 @@ impl WSLPluginV1 for Plugin {
             &self.log_file,
             "Distribution registeredd. SessionId={}, name={}, package={}",
             session.id(),
-            distribution.name().to_string_lossy(),
+            distribution.name().display(),
             distribution
                 .package_family_name()
                 .unwrap_or_default()
@@ -147,7 +147,7 @@ impl WSLPluginV1 for Plugin {
             &self.log_file,
             "Distribution unregistered. SessionId={}, name={}, package={}",
             session.id(),
-            distribution.name().to_string_lossy(),
+            distribution.name().display(),
             distribution
                 .package_family_name()
                 .unwrap_or_default()

--- a/examples/unpackaged-distro-blacklist-policy/src/lib.rs
+++ b/examples/unpackaged-distro-blacklist-policy/src/lib.rs
@@ -77,7 +77,7 @@ impl WSLPluginV1 for Plugin {
             Ok(())
         } else {
             let mut msg = OsString::from("The WSL distribution `");
-            msg.push(distribution.name());
+            msg.push(distribution.name().to_os_string());
             msg.push("` is not allowed by your organization because it is not packaged.");
             warn!("{}", msg.display());
             Err(PluginError::with_message(E_ACCESSDENIED, &msg))


### PR DESCRIPTION
## Summary

- Convert WSL distribution string helpers to borrowed UTF-16 views.
- Update distribution metadata and the unpackaged blacklist example to use the borrowed API.
- Refresh the book section covering the WSL plugin model.

## Changes

- Reworked the wide-string helper layer to return borrowed UTF-16 views instead of allocating owned strings.
- Updated the affected WSL distribution types and example code to use the borrowed API.
- Adjusted the book documentation to match the API change.

## Components Touched

- [x] Public API
- [ ] Proc macro
- [x] Runtime internals
- [x] Unsafe code
- [ ] Bug fix
- [x] Documentation
- [x] Examples
- [ ] CI / release workflow
- [ ] AGENTS.md instructions

## Validation

- [x] cargo test --workspace --all-features
- [x] cargo clippy --workspace --all-targets --all-features
- [x] cargo fmt --all -- --check
- [x] mdbook build book when the book is changed
- [x] Relevant manual testing completed

## WSL / Windows Notes

- This change does not affect plugin loading, signing, registration, or other Windows-only behavior.
- Validation was limited to the workspace test suite.

## Checklist

- [x] Tests added or updated when relevant
- [x] Documentation updated when relevant
- [x] Book updated as needed for public API changes, or the PR explains why no book update is needed
- [x] Examples updated when relevant
- [x] No unrelated changes included
