### PR TITLE
Relax dependency version constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,17 @@ members = [
     "examples/*",
 ]
 [workspace.dependencies]
-wslpluginapi-sys = "0.2.0"
+wslpluginapi-sys = "0.2"
 win-security-identifier = "0.1.1"
-windows-core = ">=0.57.0"
-windows = ">=0.57.0"
+windows-core = ">=0.59, <0.63"
+windows = ">=0.59, <0.63"
 quote = "1"
 syn = "2"
 proc-macro2 = "1"
-smallvec = "1" 
+smallvec = "1"
 widestring = "1"
 strum = { version = "0.28", features = ["derive"] }
+tracing = "0.1"
 
 [workspace.package]
 authors = ["Mickaël Véril <mika.veril@wanadoo.fr>"]

--- a/crates/wslplugins-macro-core/Cargo.toml
+++ b/crates/wslplugins-macro-core/Cargo.toml
@@ -18,11 +18,11 @@ strum = { workspace = true }
 
 [build-dependencies]
 wslpluginapi-sys = { workspace = true, features = ["hooks-field-names"] }
-quote = "1"
+quote.workspace = true
 struct-field-names-as-array = "0.3"
 
 [dev-dependencies]
-proptest = "1.9.0"
+proptest = "1"
 
 [lints]
 workspace = true

--- a/crates/wslplugins-rs/Cargo.toml
+++ b/crates/wslplugins-rs/Cargo.toml
@@ -12,13 +12,13 @@ readme.workspace = true
 
 [dependencies]
 windows-core = { workspace = true }
-bitflags = { version = ">0.1.0", optional = true }
-enumflags2 = { version = ">0.5", optional = true }
-flagset = { version = ">0.1.0", optional = true }
+bitflags = { version = "2", optional = true }
+enumflags2 = { version = "0.7", optional = true }
+flagset = { version = ">=0.1, <0.5", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-tracing = { version = "0.1.43", optional = true }
-thiserror = "2.0.7"
-typed-path = ">0.1"
+tracing = { workspace = true, optional = true }
+thiserror = "2"
+typed-path = ">=0.2, <0.13"
 widestring.workspace = true
 wslplugins-macro = { path = "../wslplugins-macro", optional = true, version = "0.1.0-beta.4" }
 wslpluginapi-sys.workspace = true
@@ -29,7 +29,7 @@ semver = { version = "1", optional = true }
 strum = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.9.0"
+proptest = "1"
 criterion = "0.8"
 serde_test = "1"
 

--- a/examples/dist-info/Cargo.toml
+++ b/examples/dist-info/Cargo.toml
@@ -17,10 +17,10 @@ wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "bitflags",
   "tracing",
 ], version = "0.1.0-beta.4" }
-tracing = "0.1"
+tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
-etc-os-release = "0.1.0"
+etc-os-release = "0.1"
 [dependencies.windows]
 workspace = true
 features = ["Win32_Foundation"]

--- a/examples/unpackaged-distro-blacklist-policy/Cargo.toml
+++ b/examples/unpackaged-distro-blacklist-policy/Cargo.toml
@@ -17,7 +17,7 @@ wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
   "bitflags",
   "tracing",
 ], version = "0.1.0-beta.4" }
-tracing = "0.1"
+tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 


### PR DESCRIPTION
## Summary

- Relax dependency constraints so downstream library consumers have more freedom to unify compatible versions.
- Replace unsafe open-ended requirements with ranges verified against the current public API and optional integrations.

## Changes

- Align `windows` and `windows-core` on the tested `>=0.59, <0.63` range because their types are exposed by the public API.
- Support `typed-path` versions from 0.2 through 0.12.
- Support `flagset` versions from 0.1 through 0.4.
- Keep `enumflags2` on 0.7 because the 0.5 and 0.6 series do not compile with the current integration.
- Relax stable dependencies to compatible major-version requirements and centralize shared `tracing` and `quote` requirements.
- No behavioral or breaking API change is intended.

## Components Touched

- [x] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [x] Bug fix
- [ ] Documentation
- [x] Examples
- [ ] CI / release workflow
- [ ] AGENTS.md instructions

## Validation

- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] `mdbook build book` when the book is changed
- [x] Relevant manual testing completed

Manual compatibility validation included:

- full workspace tests with `windows` and `windows-core` 0.59.0
- full workspace tests with `typed-path` 0.2.0, `enumflags2` 0.7.0, and `flagset` 0.1.0 simultaneously
- individual compilation checks across `typed-path` 0.2-0.12, `enumflags2` 0.5-0.7, and `flagset` 0.1-0.4

## WSL / Windows Notes

This does not change plugin loading, signing, registration, or Windows-only runtime behavior. Windows dependency compatibility was validated at the lower supported `windows` / `windows-core` 0.59.0 boundary.

## Checklist

- [x] Tests added or updated when relevant
- [x] Documentation updated when relevant
- [x] Book updated as needed for public API changes, or the PR explains why no book update is needed
- [x] Examples updated when relevant
- [x] No unrelated changes included

No documentation or book update is required because this changes dependency resolution compatibility only; the documented API and runtime behavior are unchanged.
