### PR TITLE
Create read-only host mount example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Example plugins are included:
 - `examples/dist-info`: a plugin focused on distribution metadata and tracing
 - `examples/unpackaged-distro-blacklist-policy`: a policy plugin that blocks unpackaged
   distributions
+- `examples/read-only-host-mount`: mounts a Windows directory read-only inside the WSL VM
 
 Build one of them in release mode:
 

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -109,6 +109,7 @@ The repository examples show complete plugins for common scenarios:
 - `minimal`: lifecycle hooks and command execution inside a WSL session.
 - `dist-info`: distribution metadata access.
 - `unpackaged-distro-blacklist-policy`: a policy-style plugin.
+- `read-only-host-mount`: a read-only Plan 9 mount from the Windows host into the WSL VM.
 
 Use them as references for plugin behavior, not as required workspace structure.
 

--- a/examples/read-only-host-mount/Cargo.toml
+++ b/examples/read-only-host-mount/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "read-only-host-mount"
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+readme = "README.md"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wslplugins-rs = { path = "../../crates/wslplugins-rs", features = [
+  "macro",
+], version = "0.1.0-beta.4" }
+
+[lints]
+workspace = true

--- a/examples/read-only-host-mount/README.md
+++ b/examples/read-only-host-mount/README.md
@@ -1,0 +1,60 @@
+# Read-only host mount example
+
+This example demonstrates a WSL plugin that exposes a Windows directory inside the WSL virtual machine through a read-only Plan 9 mount.
+
+It is intended as a reference for:
+
+- calling [`ApiV1::mount_folder`] from [`WSLPluginV1::on_vm_started`]
+- using the current [`SessionID`] when creating a mount
+- mapping a Windows host path to a Linux path
+- preventing WSL processes from modifying the mounted host files
+
+## What this example does
+
+When the WSL virtual machine starts, the plugin mounts:
+
+- Windows source: `C:\WSL\Shared`
+- Linux target: `/mnt/wsl-plugin-shared`
+- mount name: `wsl-plugin-shared`
+- access mode: read-only
+
+The source directory must exist on Windows before the VM starts. Create it from PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force C:\WSL\Shared
+Set-Content C:\WSL\Shared\example.txt "Hello from Windows"
+```
+
+The Linux target is created and managed by the WSL mount API. The plugin returns the Windows error reported by WSL if the mount cannot be created.
+
+## Build and deploy
+
+Build the plugin DLL:
+
+```powershell
+cargo build --release -p read-only-host-mount
+```
+
+Sign it using the repository helper:
+
+```powershell
+.\sign-plugin.ps1 -PluginPath .\target\release\read_only_host_mount.dll -Trust
+```
+
+Register the signed DLL using the deployment process described in the repository documentation, then restart WSL so the plugin is loaded and the VM-start hook runs.
+
+## Verify the mount
+
+From WSL, confirm that the host file is readable:
+
+```bash
+cat /mnt/wsl-plugin-shared/example.txt
+```
+
+Confirm that writes are rejected:
+
+```bash
+touch /mnt/wsl-plugin-shared/created-from-wsl.txt
+```
+
+The second command should fail because the mount is read-only. This setting only controls access through this WSL mount; Windows permissions and other paths to the source directory remain independent security controls.

--- a/examples/read-only-host-mount/src/lib.rs
+++ b/examples/read-only-host-mount/src/lib.rs
@@ -1,0 +1,34 @@
+#![doc = include_str!("../README.md")]
+
+use wslplugins_rs::prelude::*;
+
+const WINDOWS_SOURCE: &str = r"C:\WSL\Shared";
+const LINUX_TARGET: &str = "/mnt/wsl-plugin-shared";
+const MOUNT_NAME: &str = "wsl-plugin-shared";
+
+#[derive(Debug)]
+pub(crate) struct Plugin {
+    context: &'static WSLContext,
+}
+
+#[wsl_plugin_v1]
+impl WSLPluginV1 for Plugin {
+    fn try_new(context: &'static WSLContext) -> WinResult<Self> {
+        Ok(Self { context })
+    }
+
+    fn on_vm_started(
+        &self,
+        session: &WSLSessionInformation,
+        _user_settings: &WSLVmCreationSettings,
+    ) -> PluginResult<()> {
+        self.context.api.mount_folder(
+            session.id(),
+            WINDOWS_SOURCE,
+            LINUX_TARGET,
+            true,
+            MOUNT_NAME,
+        )?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- Add a focused WSL plugin example that mounts a Windows host directory read-only inside the WSL VM.
- Demonstrate `ApiV1::mount_folder` with a concrete setup and verification workflow for plugin authors.

## Changes

- Added the `examples/read-only-host-mount` plugin crate.
- Mounted `C:\WSL\Shared` at `/mnt/wsl-plugin-shared` during `on_vm_started` with read-only access.
- Added example documentation covering host preparation, build, signing, registration, and verification.
- Listed the example in the repository README and the getting-started book chapter.
- No public API or breaking behavior changes.

## Components Touched

- [ ] Public API
- [ ] Proc macro
- [ ] Runtime internals
- [ ] Unsafe code
- [ ] Bug fix
- [x] Documentation
- [x] Examples
- [ ] CI / release workflow
- [ ] AGENTS.md instructions

## Validation

- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] `mdbook build book` when the book is changed
- [ ] Relevant manual testing completed

Additional targeted validation: `cargo check -p read-only-host-mount`.

`mdbook build book` was not run locally. GitHub's Book workflow validates the book and Rust snippets.

## WSL / Windows Notes

This example affects Windows-only plugin behavior by creating a Plan 9 mount when the WSL VM starts. The DLL was not built in release mode, signed, registered, or loaded into WSL during local validation. The example README documents the required Windows setup and commands to verify that reads succeed and writes are rejected.

## Checklist

- [x] Tests added or updated when relevant
- [x] Documentation updated when relevant
- [x] Book updated as needed for public API changes, or the PR explains why no book update is needed
- [x] Examples updated when relevant
- [x] No unrelated changes included

No dedicated tests were added because this example is an integration with the host-provided WSL Plugin API and requires a signed and registered DLL for behavioral verification. Workspace compilation, tests, and lints cover the Rust integration.